### PR TITLE
fix: make block images work in all contexts

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -29,6 +29,7 @@ Blockly.Blocks['control_forever'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "id": "control_forever",
       "message0": Blockly.Msg.CONTROL_FOREVER,
@@ -44,7 +45,7 @@ Blockly.Blocks['control_forever'] = {
       "args2": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "repeat.svg",
+          "src": ws.options.pathToMedia + "repeat.svg",
           "width": 24,
           "height": 24,
           "alt": "*",
@@ -64,6 +65,7 @@ Blockly.Blocks['control_repeat'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "id": "control_repeat",
       "message0": Blockly.Msg.CONTROL_REPEAT,
@@ -85,7 +87,7 @@ Blockly.Blocks['control_repeat'] = {
       "args2": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "repeat.svg",
+          "src": ws.options.pathToMedia + "repeat.svg",
           "width": 24,
           "height": 24,
           "alt": "*",
@@ -267,6 +269,7 @@ Blockly.Blocks['control_repeat_until'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "message0": Blockly.Msg.CONTROL_REPEATUNTIL,
       "message1": "%1",
@@ -288,7 +291,7 @@ Blockly.Blocks['control_repeat_until'] = {
       "args2": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "repeat.svg",
+          "src": ws.options.pathToMedia + "repeat.svg",
           "width": 24,
           "height": 24,
           "alt": "*",
@@ -307,6 +310,7 @@ Blockly.Blocks['control_while'] = {
    * (This is an obsolete "hacked" block, for compatibility with 2.0.)
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "message0": Blockly.Msg.CONTROL_WHILE,
       "message1": "%1",
@@ -328,7 +332,7 @@ Blockly.Blocks['control_while'] = {
       "args2": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "repeat.svg",
+          "src": ws.options.pathToMedia + "repeat.svg",
           "width": 24,
           "height": 24,
           "alt": "*",

--- a/blocks_vertical/event.js
+++ b/blocks_vertical/event.js
@@ -71,13 +71,14 @@ Blockly.Blocks['event_whenflagclicked'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "id": "event_whenflagclicked",
       "message0": Blockly.Msg.EVENT_WHENFLAGCLICKED,
       "args0": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "green-flag.svg",
+          "src": ws.options.pathToMedia + "green-flag.svg",
           "width": 24,
           "height": 24,
           "alt": "flag"

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -48,12 +48,13 @@ Blockly.Blocks['motion_turnright'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_TURNRIGHT,
       "args0": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "rotate-right.svg",
+          "src": ws.options.pathToMedia + "rotate-right.svg",
           "width": 24,
           "height": 24
         },
@@ -74,12 +75,13 @@ Blockly.Blocks['motion_turnleft'] = {
    * @this Blockly.Block
    */
   init: function() {
+    const ws = this.workspace.options.parentWorkspace || this.workspace;
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_TURNLEFT,
       "args0": [
         {
           "type": "field_image",
-          "src": Blockly.getMainWorkspace().options.pathToMedia + "rotate-left.svg",
+          "src": ws.options.pathToMedia + "rotate-left.svg",
           "width": 24,
           "height": 24
         },

--- a/blocks_vertical/vertical_extensions.js
+++ b/blocks_vertical/vertical_extensions.js
@@ -49,6 +49,7 @@ VerticalExtensions.colourHelper = function(category) {
    * @this {Blockly.Block}
    */
   return function() {
+    this.setColour(colours.primary);
     // this.setColourFromRawValues_(colours.primary, colours.secondary,
     //     colours.tertiary, colours.quaternary);
   };
@@ -58,6 +59,7 @@ VerticalExtensions.colourHelper = function(category) {
  * Extension to set the colours of a text field, which are all the same.
  */
 VerticalExtensions.COLOUR_TEXTFIELD = function() {
+  this.setColour(colours.textField);
   // this.setColourFromRawValues_(Colours.textField,
   //     Colours.textField, Colours.textField,
   //     Colours.textField);


### PR DESCRIPTION
This PR loads block images reliably. `getMainWorkspace()` does not always return a value during early initialization, which prevented the continuous toolbox from loading these block definitions.