### PR TITLE
fix: load the continuous toolbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@blockly/continuous-toolbox": "^5.0.15",
         "blockly": "^10.0.0"
       },
       "devDependencies": {
@@ -118,6 +119,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@blockly/continuous-toolbox": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.15.tgz",
+      "integrity": "sha512-XXW+ETvPljsq9A5KdXO/aKnVbEIy+ANlgfQmPN9Vztl4U0NdQ3QvA/PtZRlZ6ISJdEkM4GnhTXOIIO+0qDqJ8w==",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^10.0.0"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -7097,6 +7109,12 @@
           }
         }
       }
+    },
+    "@blockly/continuous-toolbox": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.15.tgz",
+      "integrity": "sha512-XXW+ETvPljsq9A5KdXO/aKnVbEIy+ANlgfQmPN9Vztl4U0NdQ3QvA/PtZRlZ6ISJdEkM4GnhTXOIIO+0qDqJ8w==",
+      "requires": {}
     },
     "@commitlint/cli": {
       "version": "17.8.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
+    "@blockly/continuous-toolbox": "^5.0.15",
     "blockly": "^10.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as Blockly from 'blockly/core';
 import '../blocks_common/math.js';
 import '../blocks_vertical/vertical_extensions.js';
 import '../blocks_vertical/control.js';
@@ -15,9 +16,26 @@ import '../blocks_vertical/operators.js';
 import '../blocks_vertical/sensing.js';
 import '../blocks_vertical/sound.js';
 import * as scratchBlocksUtils from '../core/scratch_blocks_utils.js';
+import {
+  ContinuousToolbox,
+  ContinuousFlyout,
+  ContinuousMetrics,
+} from '@blockly/continuous-toolbox';
 
 export * from 'blockly';
 export * from './categories.js';
 export * from '../core/colours.js';
 export * from '../msg/scratch_msgs.js';
 export {scratchBlocksUtils};
+
+export function inject(container, options) {
+  Object.assign(options, {
+    plugins: {
+      toolbox: ContinuousToolbox,
+      flyoutsVerticalToolbox: ContinuousFlyout,
+      metricsManager: ContinuousMetrics,
+    },
+  });
+  const workspace = Blockly.inject(container, options);
+  return workspace;
+}


### PR DESCRIPTION
This PR adds the continuous toolbox plugin to scratch-blocks and overrides `inject()` to apply it. This will also allow future configuration tweaks to be applied from within scratch-blocks without clients needing to concern themselves about them.