### PR TITLE
fix: fire custom stack click event when a block stack is clicked

### DIFF
--- a/src/events_stack_click.js
+++ b/src/events_stack_click.js
@@ -1,0 +1,10 @@
+import * as Blockly from 'blockly';
+
+export class StackClickEvent extends Blockly.Events.UiBase {
+  type = 'stackClick';
+
+  constructor(blockId, workspaceId) {
+    super(workspaceId);
+    this.blockId = blockId;
+  }
+}

--- a/src/events_stack_click.js
+++ b/src/events_stack_click.js
@@ -1,4 +1,4 @@
-import * as Blockly from 'blockly';
+import * as Blockly from 'blockly/core';
 
 export class StackClickEvent extends Blockly.Events.UiBase {
   type = 'stackClick';

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import '../blocks_vertical/operators.js';
 import '../blocks_vertical/sensing.js';
 import '../blocks_vertical/sound.js';
 import * as scratchBlocksUtils from '../core/scratch_blocks_utils.js';
+import {StackClickEvent} from './events_stack_click.js';
 import {
   ContinuousToolbox,
   ContinuousFlyout,
@@ -37,5 +38,25 @@ export function inject(container, options) {
     },
   });
   const workspace = Blockly.inject(container, options);
+  registerStackClickListeners(workspace);
   return workspace;
+}
+
+function registerStackClickListeners(workspace) {
+  const blockClickHandler = (event, eventWorkspace) => {
+    if (event.type === Blockly.Events.CLICK && event.targetType === 'block') {
+      const rootBlock = eventWorkspace.getBlockById(event.blockId).getRootBlock();
+      const stackClick = new StackClickEvent(rootBlock.id, eventWorkspace.id);
+      Blockly.Events.fire(stackClick);
+    }
+  }
+  
+  const flyoutWorkspace = workspace.getFlyout().getWorkspace();
+  
+  workspace.addChangeListener((event) => {
+    blockClickHandler(event, workspace);
+  });
+  flyoutWorkspace.addChangeListener((event) => {
+    blockClickHandler(event, flyoutWorkspace);
+  });
 }


### PR DESCRIPTION
This PR adds event listeners to the main and flyout workspaces that fire a new custom StackClick event in response to clicks on blocks/stacks. In conjunction with https://github.com/gonfunko/scratch-vm/pull/1, which updates the VM to listen for these events, this re-adds support for clicking blocks/stacks to run them.