### PR TITLE
fix: hide disable and inline inputs contextual menu items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,3 +42,5 @@ export function inject(container, options) {
 }
 
 Blockly.Scrollbar.scrollbarThickness = Blockly.Touch.TOUCH_ENABLED ? 14 : 11;
+Blockly.ContextMenuRegistry.registry.unregister('blockDisable');
+Blockly.ContextMenuRegistry.registry.unregister('blockInline');


### PR DESCRIPTION
Blockly adds contextual menu items on blocks to disable them and to toggle inline/external inputs by default. Scratch does not support these options; this PR unregisters the menu items to match that behavior.