### PR TITLE
fix: use Scratch-style text blocks

### DIFF
--- a/blocks_common/text.js
+++ b/blocks_common/text.js
@@ -22,15 +22,8 @@
  * @fileoverview Text blocks for Blockly.
  * @author fraser@google.com (Neil Fraser)
  */
-'use strict';
-
-goog.provide('Blockly.Blocks.texts');
-
-goog.require('Blockly.Blocks');
-
-goog.require('Blockly.Colours');
-
-goog.require('Blockly.constants');
+import * as Blockly from 'blockly';
+import {Colours} from '../core/colours.js';
 
 Blockly.Blocks['text'] = {
   /**
@@ -47,11 +40,10 @@ Blockly.Blocks['text'] = {
         }
       ],
       "output": "String",
-      "outputShape": Blockly.OUTPUT_SHAPE_ROUND,
-      "colour": Blockly.Colours.textField,
-      "colourSecondary": Blockly.Colours.textField,
-      "colourTertiary": Blockly.Colours.textField,
-      "colourQuaternary": Blockly.Colours.textField
+      "colour": Colours.textField,
+      "colourSecondary": Colours.textField,
+      "colourTertiary": Colours.textField,
+      "colourQuaternary": Colours.textField
     });
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 import '../blocks_common/math.js';
+import '../blocks_common/text.js';
 import '../blocks_vertical/vertical_extensions.js';
 import '../blocks_vertical/control.js';
 import '../blocks_vertical/data.js';


### PR DESCRIPTION
This PR uses Scratch-style rounded text blocks instead of the Blockly-style ones with quotation mark graphics.