### PR TITLE
fix: reenable support for checkboxes in the flyout

### DIFF
--- a/blocks_vertical/data.js
+++ b/blocks_vertical/data.js
@@ -42,9 +42,9 @@ Blockly.Blocks['data_variable'] = {
         }
       ],
       "category": Categories.data,
-      "checkboxInFlyout": true,
       "extensions": ["contextMenu_getVariableBlock", "colours_data", "output_string"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -158,8 +158,8 @@ Blockly.Blocks['data_listcontents'] = {
       ],
       "category": Categories.dataLists,
       "extensions": ["contextMenu_getListBlock", "colours_data_lists", "output_string"],
-      "checkboxInFlyout": true
     });
+    this.checkboxInFlyout = true;
   }
 };
 

--- a/blocks_vertical/looks.js
+++ b/blocks_vertical/looks.js
@@ -282,9 +282,9 @@ Blockly.Blocks['looks_size'] = {
     this.jsonInit({
       "message0": Blockly.Msg.LOOKS_SIZE,
       "category": Categories.looks,
-      "checkboxInFlyout": true,
       "extensions": ["colours_looks", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -510,9 +510,9 @@ Blockly.Blocks['looks_backdropnumbername'] = {
         }
       ],
       "category": Categories.looks,
-      "checkboxInFlyout": true,
       "extensions": ["colours_looks", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -535,9 +535,9 @@ Blockly.Blocks['looks_costumenumbername'] = {
         }
       ],
       "category": Categories.looks,
-      "checkboxInFlyout": true,
       "extensions": ["colours_looks", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 

--- a/blocks_vertical/motion.js
+++ b/blocks_vertical/motion.js
@@ -429,9 +429,9 @@ Blockly.Blocks['motion_xposition'] = {
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_XPOSITION,
       "category": Categories.motion,
-      "checkboxInFlyout": true,
       "extensions": ["colours_motion", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -444,9 +444,9 @@ Blockly.Blocks['motion_yposition'] = {
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_YPOSITION,
       "category": Categories.motion,
-      "checkboxInFlyout": true,
       "extensions": ["colours_motion", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -459,9 +459,9 @@ Blockly.Blocks['motion_direction'] = {
     this.jsonInit({
       "message0": Blockly.Msg.MOTION_DIRECTION,
       "category": Categories.motion,
-      "checkboxInFlyout": true,
       "extensions": ["colours_motion", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 

--- a/blocks_vertical/sensing.js
+++ b/blocks_vertical/sensing.js
@@ -179,9 +179,9 @@ Blockly.Blocks['sensing_answer'] = {
     this.jsonInit({
       "message0": Blockly.Msg.SENSING_ANSWER,
       "category": Categories.sensing,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -343,9 +343,9 @@ Blockly.Blocks['sensing_loudness'] = {
     this.jsonInit({
       "message0": Blockly.Msg.SENSING_LOUDNESS,
       "category": Categories.sensing,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -374,9 +374,9 @@ Blockly.Blocks['sensing_timer'] = {
     this.jsonInit({
       "message0": Blockly.Msg.SENSING_TIMER,
       "category": Categories.sensing,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -480,9 +480,9 @@ Blockly.Blocks['sensing_current'] = {
         }
       ],
       "category": Categories.sensing,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 
@@ -509,9 +509,9 @@ Blockly.Blocks['sensing_username'] = {
     this.jsonInit({
       "message0": Blockly.Msg.SENSING_USERNAME,
       "category": Categories.sensing,
-      "checkboxInFlyout": true,
       "extensions": ["colours_sensing", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };
 

--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -205,5 +205,6 @@ Blockly.Blocks['sound_volume'] = {
       "checkboxInFlyout": true,
       "extensions": ["colours_sounds", "output_number"]
     });
+    this.checkboxInFlyout = true;
   }
 };

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -126,12 +126,12 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     var checkboxState = this.getCheckboxState(block.id);
     var svgRoot = block.getSvgRoot();
     var extraSpace = CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN;
-    var width = this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX;
-    var height = cursorY + blockHW.height / 2 - CheckableContinuousFlyout.CHECKBOX_SIZE / 2;
+    var xOffset = this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX;
+    var yOffset = cursorY + blockHW.height / 2 - CheckableContinuousFlyout.CHECKBOX_SIZE / 2;
     var touchMargin = CheckableContinuousFlyout.CHECKBOX_TOUCH_PADDING;
     var checkboxGroup = Blockly.utils.dom.createSvgElement('g',
         {
-          'transform': 'translate(' + width + ', ' + height + ')',
+          'transform': `translate(${xOffset}, ${yOffset})`,
           'fill': 'transparent',
         }, null);
     Blockly.utils.dom.createSvgElement('rect',

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -89,9 +89,6 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       } else {
         moveX += CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN;
       }
-      if (Number.isNaN(moveX)) {
-        debugger;
-      }
       block.moveBy(moveX, 0);
       this.listeners.push(Blockly.browserEvents.bind(block.flyoutCheckbox.svgRoot,
       'mousedown', null, this.checkboxClicked_(block.flyoutCheckbox)));

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -73,7 +73,6 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
 
   clearOldCheckboxes() {
     for (const checkbox of this.checkboxes_.values()) {
-      checkbox.block.flyoutCheckbox = null;
       checkbox.svgRoot.remove();
     }
     this.checkboxes_.clear();
@@ -82,7 +81,8 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
   addBlockListeners_(root, block, rect) {
     if (block.checkboxInFlyout) {
       const coordinates = block.getRelativeToSurfaceXY();
-      this.createCheckbox_(block, coordinates.x, coordinates.y, block.getHeightWidth());
+      const checkbox = this.createCheckbox_(
+          block, coordinates.x, coordinates.y, block.getHeightWidth());
       let moveX = coordinates.x;
       if (this.RTL) {
         moveX -= (CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN);
@@ -90,8 +90,8 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
         moveX += CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN;
       }
       block.moveBy(moveX, 0);
-      this.listeners.push(Blockly.browserEvents.bind(block.flyoutCheckbox.svgRoot,
-          'mousedown', null, this.checkboxClicked_(block.flyoutCheckbox)));
+      this.listeners.push(Blockly.browserEvents.bind(checkbox.svgRoot,
+          'mousedown', null, this.checkboxClicked_(checkbox)));
     }
     super.addBlockListeners_(root, block, rect);
   }
@@ -161,9 +161,9 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       Blockly.utils.dom.addClass((checkboxObj.svgRoot), 'checked');
     }
 
-    block.flyoutCheckbox = checkboxObj;
     this.workspace_.getCanvas().insertBefore(checkboxGroup, svgRoot);
     this.checkboxes_.set(block.id, checkboxObj);
+    return checkboxObj;
   }
 
   /**

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -1,0 +1,209 @@
+import * as Blockly from 'blockly';
+import {ContinuousFlyout} from '@blockly/continuous-toolbox';
+
+export class CheckableContinuousFlyout extends ContinuousFlyout {
+  /**
+   * Size of a checkbox next to a variable reporter.
+   * @type {number}
+   * @const
+   */
+  static CHECKBOX_SIZE = 25;
+
+  /**
+   * Amount of touchable padding around reporter checkboxes.
+   * @type {number}
+   * @const
+   */
+  static CHECKBOX_TOUCH_PADDING = 12;
+
+  /**
+   * SVG path data for checkmark in checkbox.
+   * @type {string}
+   * @const
+   */
+  static CHECKMARK_PATH =
+      'M' + CheckableContinuousFlyout.CHECKBOX_SIZE / 4 +
+      ' ' + CheckableContinuousFlyout.CHECKBOX_SIZE / 2 +
+      'L' + 5 * CheckableContinuousFlyout.CHECKBOX_SIZE / 12 +
+      ' ' + 2 * CheckableContinuousFlyout.CHECKBOX_SIZE / 3 +
+      'L' + 3 * CheckableContinuousFlyout.CHECKBOX_SIZE / 4 +
+      ' ' + CheckableContinuousFlyout.CHECKBOX_SIZE / 3;
+
+  /**
+   * Size of the checkbox corner radius
+   * @type {number}
+   * @const
+   */
+  static CHECKBOX_CORNER_RADIUS = 5;
+
+  /**
+   * @type {number}
+   * @const
+   */
+  static CHECKBOX_MARGIN = ContinuousFlyout.prototype.MARGIN;
+
+  /**
+   * Total additional width of a row that contains a checkbox.
+   * @type {number}
+   * @const
+   */
+  static CHECKBOX_SPACE_X =
+      CheckableContinuousFlyout.CHECKBOX_SIZE +
+      2 * CheckableContinuousFlyout.CHECKBOX_MARGIN;
+
+
+  constructor(workspaceOptions) {
+    super(workspaceOptions);
+    CheckableContinuousFlyout.CHECKBOX_MARGIN = this.MARGIN;
+
+    /**
+     * Map of checkboxes that correspond to monitored blocks.
+     * Each element is an object containing the SVG for the checkbox, a boolean
+     * for its checked state, and the block the checkbox is associated with.
+     * @type {!Object.<string, !Object>}
+     * @private
+     */
+    this.checkboxes_ = {};
+  }
+
+  show(flyoutDef) {
+    this.clearOldCheckboxes();
+    super.show(flyoutDef);
+  }
+
+  clearOldCheckboxes() {
+    for (const checkboxId in this.checkboxes_) {
+      if (!this.checkboxes_.hasOwnProperty(checkboxId)) continue;
+      const checkbox = this.checkboxes_[checkboxId];
+      checkbox.block.flyoutCheckbox = null;
+      checkbox.svgRoot.remove();
+    }
+    this.checkboxes_ = {};
+  }
+
+  addBlockListeners_(root, block, rect) {
+    if (block.checkboxInFlyout) {
+      const coordinates = block.getRelativeToSurfaceXY();
+      this.createCheckbox_(block, coordinates.x, coordinates.y, block.getHeightWidth());
+      let moveX = coordinates.x;
+      if (this.RTL) {
+        moveX -= (CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN);
+      } else {
+        moveX += CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN;
+      }
+      if (Number.isNaN(moveX)) {
+        debugger;
+      }
+      block.moveBy(moveX, 0);
+      this.listeners.push(Blockly.browserEvents.bind(block.flyoutCheckbox.svgRoot,
+      'mousedown', null, this.checkboxClicked_(block.flyoutCheckbox)));
+    }
+    super.addBlockListeners_(root, block, rect);
+  }
+
+  /**
+   * Respond to a click on a checkbox in the flyout.
+   * @param {!Object} checkboxObj An object containing the svg element of the
+   *    checkbox, a boolean for the state of the checkbox, and the block the
+   *    checkbox is associated with.
+   * @return {!Function} Function to call when checkbox is clicked.
+   * @private
+   */
+  checkboxClicked_(checkboxObj) {
+    return function(e) {
+      this.setCheckboxState(checkboxObj.block.id, !checkboxObj.clicked);
+      // This event has been handled.  No need to bubble up to the document.
+      e.stopPropagation();
+      e.preventDefault();
+    }.bind(this);
+  }
+
+  /**
+   * Create and place a checkbox corresponding to the given block.
+   * @param {!Blockly.Block} block The block to associate the checkbox to.
+   * @param {number} cursorX The x position of the cursor during this layout pass.
+   * @param {number} cursorY The y position of the cursor during this layout pass.
+   * @param {!{height: number, width: number}} blockHW The height and width of the
+   *     block.
+   * @private
+   */
+  createCheckbox_(block, cursorX, cursorY, blockHW) {
+    var checkboxState = this.getCheckboxState(block.id);
+    var svgRoot = block.getSvgRoot();
+    var extraSpace = CheckableContinuousFlyout.CHECKBOX_SIZE + CheckableContinuousFlyout.CHECKBOX_MARGIN;
+    var width = this.RTL ? this.getWidth() / this.workspace_.scale - extraSpace : cursorX;
+    var height = cursorY + blockHW.height / 2 - CheckableContinuousFlyout.CHECKBOX_SIZE / 2;
+    var touchMargin = CheckableContinuousFlyout.CHECKBOX_TOUCH_PADDING;
+    var checkboxGroup = Blockly.utils.dom.createSvgElement('g',
+        {
+          'transform': 'translate(' + width + ', ' + height + ')',
+          'fill': 'transparent',
+        }, null);
+    Blockly.utils.dom.createSvgElement('rect',
+        {
+          'class': 'blocklyFlyoutCheckbox',
+          'height': CheckableContinuousFlyout.CHECKBOX_SIZE,
+          'width': CheckableContinuousFlyout.CHECKBOX_SIZE,
+          'rx': CheckableContinuousFlyout.CHECKBOX_CORNER_RADIUS,
+          'ry': CheckableContinuousFlyout.CHECKBOX_CORNER_RADIUS
+        }, checkboxGroup);
+    Blockly.utils.dom.createSvgElement('path',
+        {
+          'class': 'blocklyFlyoutCheckboxPath',
+          'd': CheckableContinuousFlyout.CHECKMARK_PATH
+        }, checkboxGroup);
+    Blockly.utils.dom.createSvgElement('rect',
+        {
+          'class': 'blocklyTouchTargetBackground',
+          'x': -touchMargin + 'px',
+          'y': -touchMargin + 'px',
+          'height': CheckableContinuousFlyout.CHECKBOX_SIZE + 2 * touchMargin,
+          'width': CheckableContinuousFlyout.CHECKBOX_SIZE + 2 * touchMargin,
+        }, checkboxGroup);
+    var checkboxObj = {svgRoot: checkboxGroup, clicked: checkboxState, block: block};
+
+    if (checkboxState) {
+      Blockly.utils.dom.addClass((checkboxObj.svgRoot), 'checked');
+    }
+
+    block.flyoutCheckbox = checkboxObj;
+    this.workspace_.getCanvas().insertBefore(checkboxGroup, svgRoot);
+    this.checkboxes_[block.id] = checkboxObj;
+  }
+
+  /**
+   * Set the state of a checkbox by block ID.
+   * @param {string} blockId ID of the block whose checkbox should be set
+   * @param {boolean} value Value to set the checkbox to.
+   * @public
+   */
+  setCheckboxState(blockId, value) {
+    var checkboxObj = this.checkboxes_[blockId];
+    if (!checkboxObj || checkboxObj.clicked === value) {
+      return;
+    }
+
+    var oldValue = checkboxObj.clicked;
+    checkboxObj.clicked = value;
+
+    if (checkboxObj.clicked) {
+      Blockly.utils.dom.addClass(checkboxObj.svgRoot, 'checked');
+    } else {
+      Blockly.utils.dom.removeClass(checkboxObj.svgRoot, 'checked');
+    }
+
+    Blockly.Events.fire(new Blockly.Events.BlockChange(
+        checkboxObj.block, 'checkbox', null, oldValue, value));
+  }
+
+  /**
+   * Gets the checkbox state for a block
+   * @param {string} blockId The ID of the block in question.
+   * @return {boolean} Whether the block is checked.
+   * @public
+   */
+  getCheckboxState() {
+    // Patched by scratch-gui in src/lib/blocks.js.
+    return false;
+  }
+}

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -91,7 +91,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       }
       block.moveBy(moveX, 0);
       this.listeners.push(Blockly.browserEvents.bind(block.flyoutCheckbox.svgRoot,
-      'mousedown', null, this.checkboxClicked_(block.flyoutCheckbox)));
+          'mousedown', null, this.checkboxClicked_(block.flyoutCheckbox)));
     }
     super.addBlockListeners_(root, block, rect);
   }

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -63,7 +63,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
      * @type {!Object.<string, !Object>}
      * @private
      */
-    this.checkboxes_ = {};
+    this.checkboxes_ = new Map();
   }
 
   show(flyoutDef) {
@@ -72,13 +72,11 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
   }
 
   clearOldCheckboxes() {
-    for (const checkboxId in this.checkboxes_) {
-      if (!this.checkboxes_.hasOwnProperty(checkboxId)) continue;
-      const checkbox = this.checkboxes_[checkboxId];
+    for (const checkbox of this.checkboxes_.values()) {
       checkbox.block.flyoutCheckbox = null;
       checkbox.svgRoot.remove();
     }
-    this.checkboxes_ = {};
+    this.checkboxes_.clear();
   }
 
   addBlockListeners_(root, block, rect) {
@@ -168,7 +166,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
 
     block.flyoutCheckbox = checkboxObj;
     this.workspace_.getCanvas().insertBefore(checkboxGroup, svgRoot);
-    this.checkboxes_[block.id] = checkboxObj;
+    this.checkboxes_.set(block.id, checkboxObj);
   }
 
   /**
@@ -178,7 +176,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
    * @public
    */
   setCheckboxState(blockId, value) {
-    var checkboxObj = this.checkboxes_[blockId];
+    var checkboxObj = this.checkboxes_.get(blockId);
     if (!checkboxObj || checkboxObj.clicked === value) {
       return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ import {
   ContinuousFlyout,
   ContinuousMetrics,
 } from '@blockly/continuous-toolbox';
-
+import {CheckableContinuousFlyout} from './checkable_continuous_flyout.js';
 import './scratch_continuous_category.js';
 
 export * from 'blockly';
@@ -35,12 +35,13 @@ export * from '../core/colours.js';
 export * from '../core/field_colour_slider.js';
 export * from '../msg/scratch_msgs.js';
 export {scratchBlocksUtils};
+export {CheckableContinuousFlyout};
 
 export function inject(container, options) {
   Object.assign(options, {
     plugins: {
       toolbox: ContinuousToolbox,
-      flyoutsVerticalToolbox: ContinuousFlyout,
+      flyoutsVerticalToolbox: CheckableContinuousFlyout,
       metricsManager: ContinuousMetrics,
     },
   });


### PR DESCRIPTION
This PR adds support for displaying checkboxes next to reporter blocks in the continuous flyout.