### PR TITLE
fix: preserve toolbox category IDs

### DIFF
--- a/src/scratch_continuous_category.js
+++ b/src/scratch_continuous_category.js
@@ -2,6 +2,11 @@ import * as Blockly from 'blockly/core';
 import {ContinuousCategory} from '@blockly/continuous-toolbox';
 
 class ScratchContinuousCategory extends ContinuousCategory {
+  constructor(categoryDef, toolbox) {
+    categoryDef['toolboxitemid'] = categoryDef['id'];
+    super(categoryDef, toolbox);
+  }
+
   createIconDom_() {
     if (this.toolboxItemDef_.iconURI) {
       const icon = document.createElement('img');


### PR DESCRIPTION
This PR copies the toolbox category ID to the correct key for modern Blockly. This is required for https://github.com/gonfunko/scratch-gui/pull/8 to work end-to-end.