### PR TITLE
fix: reenable reporting block values

### DIFF
--- a/src/block_reporting.js
+++ b/src/block_reporting.js
@@ -1,0 +1,21 @@
+import * as Blockly from 'blockly/core';
+import {Colours} from '../core/colours.js';
+
+export function reportValue(id, value) {
+  const block = Blockly.getMainWorkspace().getBlockById(id) ||
+      Blockly.getMainWorkspace().getFlyout().getWorkspace().getBlockById(id);
+  const field = block.inputList[0].fieldRow[0];
+  if (!block) {
+    throw 'Tried to report value on block that does not exist.';
+  }
+  const contentDiv = Blockly.DropDownDiv.getContentDiv();
+  const valueReportBox = document.createElement('div');
+  valueReportBox.setAttribute('class', 'valueReportBox');
+  valueReportBox.innerText = value;
+  contentDiv.appendChild(valueReportBox);
+  Blockly.DropDownDiv.setColour(
+      Colours.valueReportBackground,
+      Colours.valueReportBorder
+  );
+  Blockly.DropDownDiv.showPositionedByBlock(field, block);
+}

--- a/src/block_reporting.js
+++ b/src/block_reporting.js
@@ -4,10 +4,10 @@ import {Colours} from '../core/colours.js';
 export function reportValue(id, value) {
   const block = Blockly.getMainWorkspace().getBlockById(id) ||
       Blockly.getMainWorkspace().getFlyout().getWorkspace().getBlockById(id);
-  const field = block.inputList[0].fieldRow[0];
   if (!block) {
     throw 'Tried to report value on block that does not exist.';
   }
+  const field = block.inputList[0].fieldRow[0];
   const contentDiv = Blockly.DropDownDiv.getContentDiv();
   const valueReportBox = document.createElement('div');
   valueReportBox.setAttribute('class', 'valueReportBox');

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -74,6 +74,16 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     super.show(flyoutDef);
   }
 
+  serializeBlock(block) {
+    const json = super.serializeBlock(block);
+    // Delete the serialized block's ID so that a new one is generated when it is
+    // placed on the workspace. Otherwise, the block on the workspace may be
+    // indistinguishable from the one in the flyout, which can cause reporter blocks
+    // to have their value dropdown shown in the wrong place.
+    delete json.id;
+    return json;
+  }
+
   clearOldCheckboxes() {
     for (const checkbox of this.checkboxes_.values()) {
       checkbox.svgRoot.remove();

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ import {CheckableContinuousFlyout} from './checkable_continuous_flyout.js';
 import './scratch_continuous_category.js';
 
 export * from 'blockly';
+export * from './block_reporting.js';
 export * from './categories.js';
 export * from './procedures.js';
 export * from '../core/colours.js';


### PR DESCRIPTION
This PR moves the reportValue function out of the workspace and into its own utility function. This is used to show the value of reporter (oval) blocks on click in a dropdown.