### PR TITLE
fix: resolve error when adding the stop block to the workspace

### DIFF
--- a/blocks_vertical/control.js
+++ b/blocks_vertical/control.js
@@ -188,17 +188,8 @@ Blockly.Blocks['control_stop'] = {
         [Blockly.Msg.CONTROL_STOP_OTHER, OTHER_SCRIPTS]
       ];
     }, function(option) {
-      // Create an event group to keep field value and mutator in sync
-      // Return null at the end because setValue is called here already.
-      Blockly.Events.setGroup(true);
-      var oldMutation = Blockly.Xml.domToText(this.sourceBlock_.mutationToDom());
-      this.sourceBlock_.setNextStatement(option == OTHER_SCRIPTS);
-      var newMutation = Blockly.Xml.domToText(this.sourceBlock_.mutationToDom());
-      Blockly.Events.fire(new Blockly.Events.BlockChange(this.sourceBlock_,
-          'mutation', null, oldMutation, newMutation));
-      this.setValue(option);
-      Blockly.Events.setGroup(false);
-      return null;
+      this.getSourceBlock().setNextStatement(option === OTHER_SCRIPTS);
+      return option;
     });
     this.appendDummyInput()
         .appendField(Blockly.Msg.CONTROL_STOP)
@@ -209,15 +200,6 @@ Blockly.Blocks['control_stop'] = {
         Colours.control.quaternary
     );
     this.setPreviousStatement(true);
-  },
-  mutationToDom: function() {
-    var container = document.createElement('mutation');
-    container.setAttribute('hasnext', this.nextConnection != null);
-    return container;
-  },
-  domToMutation: function(xmlElement) {
-    var hasNext = (xmlElement.getAttribute('hasnext') == 'true');
-    this.setNextStatement(hasNext);
   }
 };
 


### PR DESCRIPTION
This PR resolves an issue that prevented dragging out the `stop` block.