### PR TITLE
chore: update to the latest continuous toolbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@blockly/continuous-toolbox": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.15.tgz",
-      "integrity": "sha512-XXW+ETvPljsq9A5KdXO/aKnVbEIy+ANlgfQmPN9Vztl4U0NdQ3QvA/PtZRlZ6ISJdEkM4GnhTXOIIO+0qDqJ8w==",
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.17.tgz",
+      "integrity": "sha512-3JCSimCo5KEWvvN4qC66vs2L/WtJIHepoIfkPNcbvMwjwYxJ484UPK2LKdlyI1842mgFfcYM3nTERjfa+Q4rXA==",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -7123,9 +7123,9 @@
       }
     },
     "@blockly/continuous-toolbox": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.15.tgz",
-      "integrity": "sha512-XXW+ETvPljsq9A5KdXO/aKnVbEIy+ANlgfQmPN9Vztl4U0NdQ3QvA/PtZRlZ6ISJdEkM4GnhTXOIIO+0qDqJ8w==",
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@blockly/continuous-toolbox/-/continuous-toolbox-5.0.17.tgz",
+      "integrity": "sha512-3JCSimCo5KEWvvN4qC66vs2L/WtJIHepoIfkPNcbvMwjwYxJ484UPK2LKdlyI1842mgFfcYM3nTERjfa+Q4rXA==",
       "requires": {}
     },
     "@blockly/field-colour": {


### PR DESCRIPTION
This PR updates to the latest version of the continuous toolbox plugin, which includes https://github.com/google/blockly-samples/pull/2337, which was necessary for the toolbox scroll position preservation logic introduced in https://github.com/gonfunko/scratch-gui/pull/10 to work. It looks like there's also a regression where the first category isn't visibly selected on load, but I think I prefer maintaining scroll position to that for now, and will fix that in a followup.