### PR TITLE
fix: improve reliability of block value reporting

### DIFF
--- a/src/block_reporting.js
+++ b/src/block_reporting.js
@@ -7,7 +7,16 @@ export function reportValue(id, value) {
   if (!block) {
     throw 'Tried to report value on block that does not exist.';
   }
-  const field = block.inputList[0].fieldRow[0];
+
+  let field;
+  for (const input of block.inputList) {
+    for (const f of input.fieldRow) {
+      field = f;
+      break;
+    }
+  }
+  if (!field) return;
+
   const contentDiv = Blockly.DropDownDiv.getContentDiv();
   const valueReportBox = document.createElement('div');
   valueReportBox.setAttribute('class', 'valueReportBox');

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -221,6 +221,9 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
 
   blockIsRecyclable_(block) {
     const recyclable = super.blockIsRecyclable_(block);
+    // Exclude blocks with output connections, because they are able to report their current
+    // value in a popover and recycling them interacts poorly with the VM's maintenance of its
+    // state.
     return recyclable && !block.outputConnection;
   }
 }

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -218,4 +218,9 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
   getFlyoutScale() {
     return 0.675;
   }
+
+  blockIsRecyclable_(block) {
+    const recyclable = super.blockIsRecyclable_(block);
+    return recyclable && !block.outputConnection;
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import {
   ContinuousMetrics,
 } from '@blockly/continuous-toolbox';
 import {CheckableContinuousFlyout} from './checkable_continuous_flyout.js';
+import {ScratchContinuousToolbox} from './scratch_continuous_toolbox.js';
 import {buildGlowFilter, glowStack} from './glows.js';
 import './scratch_continuous_category.js';
 
@@ -51,7 +52,7 @@ export {CheckableContinuousFlyout};
 export function inject(container, options) {
   Object.assign(options, {
     plugins: {
-      toolbox: ContinuousToolbox,
+      toolbox: ScratchContinuousToolbox,
       flyoutsVerticalToolbox: CheckableContinuousFlyout,
       metricsManager: ContinuousMetrics,
     },

--- a/src/scratch_continuous_toolbox.js
+++ b/src/scratch_continuous_toolbox.js
@@ -1,0 +1,12 @@
+import * as Blockly from 'blockly/core';
+import {ContinuousToolbox} from '@blockly/continuous-toolbox';
+
+export class ScratchContinuousToolbox extends ContinuousToolbox {
+  refreshSelection() {
+    // Intentionally a no-op, Scratch manually manages refreshing the toolbox via forceRerender().
+  }
+
+  forceRerender() {
+    super.refreshSelection();
+  }
+}


### PR DESCRIPTION
This PR, in conjunction with https://github.com/gonfunko/scratch-gui/pull/14, makes block value reporting work consistently for all report-able blocks. Previously, reporting blocks that were present for both the stage and sprites didn't report their values correctly. This seems to be because block recycling interfered with the VM's monitoring of the state of truth, which has been resolved by excluding reporting blocks (those with an output) from recycling.

Finding of fields for blocks when reporting is invoked has been made more reliable, vs just assuming that there would be one in the fieldrow of the first item in a block's inputList.

Finally, this PR disables the normal toolbox refresh method, since Scratch manually manages toolbox refreshes for performance reasons. An additional method to force a refresh has been added for use by scratch-gui.