### PR TITLE
fix: match Scratch behaviors around dragging and connection stickiness

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,12 @@ export function inject(container, options) {
 
   buildGlowFilter(workspace);
 
+  Blockly.config.dragRadius = 3;
+  Blockly.config.snapRadius = 48;
+  Blockly.config.connectingSnapRadius = 68;
+  Blockly.config.currentConnectionPreference = 20;
+  Blockly.config.bumpDelay = 0;
+
   return workspace;
 }
 


### PR DESCRIPTION
This PR updates various constants to match the Scratch values (from core/constants.js) to adjust how sticky blocks/drags are.

Fixes #65