### PR TITLE
chore: upgrade to Blockly v11

### DIFF
--- a/msg/scratch_msgs.js
+++ b/msg/scratch_msgs.js
@@ -1,17 +1,20 @@
-import * as Blockly from 'blockly';
+import * as Blockly from 'blockly/core';
 
-const ScratchMsgs = {
-  currentLocale_: 'en',
-  setLocale: function(locale) {
+export class ScratchMsgs {
+  static currentLocale_ = 'en';
+  static locales = {};
+
+  static setLocale(locale) {
     if (Object.keys(this.locales).includes(locale)) {
       this.currentLocale_ = locale;
-      Blockly.Msg = Object.assign({}, Blockly.Msg, this.locales[locale]);
+      Object.assign(Blockly.Msg, this.locales[locale]);
     } else {
       // keep current locale
       console.warn('Ignoring unrecognized locale: ' + locale);
     }
-  },
-  translate: function(msgId, defaultMsg, useLocale) {
+  }
+
+  static translate(msgId, defaultMsg, useLocale) {
     var locale = useLocale || this.currentLocale_;
 
     if (Object.keys(this.locales).includes(locale)) {
@@ -21,9 +24,8 @@ const ScratchMsgs = {
       }
     }
     return defaultMsg;
-  },
-  locales: {},
-};
+  }
+}
 
 ScratchMsgs.locales["ab"] =
 {
@@ -22985,5 +22987,3 @@ ScratchMsgs.locales["zh-tw"] =
     "DEFAULT_BROADCAST_MESSAGE_NAME": "message1"
 };
 // End of combined translations
-
-export {ScratchMsgs};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@blockly/continuous-toolbox": "^5.0.15",
         "@blockly/field-angle": "^4.0.2",
         "@blockly/field-colour": "^4.0.2",
-        "blockly": "^11.0.0-beta.11"
+        "blockly": "^11.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.11.tgz",
-      "integrity": "sha512-re2FiKJ9WVigldQShnZAinMZw7V0fjgHstOgHQsG/2ARnmu3xOhPsEq059+d+WtMgM09UXl1liYO76dTZPuD+w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0.tgz",
+      "integrity": "sha512-6Ie7HuZWZLaETIVKFEP4FPDz267Pubn6+weQNZvXzqnkOYp9sKPSsPue8QIMCV9Qb5F4wYhqivgiDcZJcE1UlQ==",
       "dependencies": {
         "jsdom": "23.0.0"
       },
@@ -8147,9 +8147,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.11.tgz",
-      "integrity": "sha512-re2FiKJ9WVigldQShnZAinMZw7V0fjgHstOgHQsG/2ARnmu3xOhPsEq059+d+WtMgM09UXl1liYO76dTZPuD+w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0.tgz",
+      "integrity": "sha512-6Ie7HuZWZLaETIVKFEP4FPDz267Pubn6+weQNZvXzqnkOYp9sKPSsPue8QIMCV9Qb5F4wYhqivgiDcZJcE1UlQ==",
       "requires": {
         "jsdom": "23.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "@blockly/continuous-toolbox": "^5.0.15",
     "@blockly/field-angle": "^4.0.2",
     "@blockly/field-colour": "^4.0.2",
-    "blockly": "^11.0.0-beta.11"
+    "blockly": "^11.0.0"
   }
 }


### PR DESCRIPTION
This PR upgrades scratch-blocks to use the final release version of Blockly 11.

Due to the new bundling approach, scratch_msgs.js also had to be updated to modify Blockly.Msgs in place, rather than assigning a new value to it.

This also fixes #74 thanks to a fix in upstream.