### PR TITLE
fix: add support for Scratch-style block comments

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -1288,6 +1288,10 @@ const styles = `
     height: 1.25rem;
   }
 
+  .blocklyComment {
+    --colour-commentBorder: #bcA903;
+  }
+
   .blocklyCommentTopbar {
     height: 32px;
     --commentBorderColour: #e2db96;
@@ -1307,7 +1311,7 @@ const styles = `
   .blocklySelected .blocklyCommentHighlight,
   .blocklyCollapsed .blocklyCommentTopbarBackground,
   .blocklyCollapsed.blocklySelected .blocklyCommentTopbarBackground {
-    stroke: #bcA903;
+    stroke: var(--colour-commentBorder);
     stroke-width: 1px;
   }
 

--- a/src/events_block_comment_base.js
+++ b/src/events_block_comment_base.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 
 export class BlockCommentBase extends Blockly.Events.Abstract {

--- a/src/events_block_comment_base.js
+++ b/src/events_block_comment_base.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
+import * as Blockly from "blockly/core";
 
 export class BlockCommentBase extends Blockly.Events.Abstract {
   constructor(opt_blockComment) {
@@ -22,14 +22,14 @@ export class BlockCommentBase extends Blockly.Events.Abstract {
     return {
       ...super.toJson(),
       commentId: this.commentId,
-      blockId: this.blockId
+      blockId: this.blockId,
     };
   }
 
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
-    newEvent.commentId = json['commentId'];
-    newEvent.blockId = json['blockId'];
+    newEvent.commentId = json["commentId"];
+    newEvent.blockId = json["blockId"];
     return newEvent;
   }
 }

--- a/src/events_block_comment_base.js
+++ b/src/events_block_comment_base.js
@@ -9,10 +9,7 @@ import * as Blockly from 'blockly/core';
 export class BlockCommentBase extends Blockly.Events.Abstract {
   constructor(opt_blockComment) {
     super();
-
     this.isBlank = !opt_blockComment;
-    this.group = Blockly.Events.getGroup();
-    this.recordUndo = Blockly.Events.getRecordUndo();
 
     if (!opt_blockComment) return;
 

--- a/src/events_block_comment_base.js
+++ b/src/events_block_comment_base.js
@@ -1,0 +1,32 @@
+import * as Blockly from 'blockly/core';
+
+export class BlockCommentBase extends Blockly.Events.Abstract {
+  constructor(opt_blockComment) {
+    super();
+
+    this.isBlank = !opt_blockComment;
+    this.group = Blockly.Events.getGroup();
+    this.recordUndo = Blockly.Events.getRecordUndo();
+
+    if (!opt_blockComment) return;
+
+    this.commentId = opt_blockComment.getId();
+    this.blockId = opt_blockComment.getSourceBlock()?.id;
+    this.workspaceId = opt_blockComment.getSourceBlock()?.workspace.id;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      commentId: this.commentId,
+      blockId: this.blockId
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.commentId = json['commentId'];
+    newEvent.blockId = json['blockId'];
+    return newEvent;
+  }
+}

--- a/src/events_block_comment_change.js
+++ b/src/events_block_comment_change.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentChange extends BlockCommentBase {
   constructor(opt_blockComment, oldContents, newContents) {
     super(opt_blockComment);
-    this.type = 'block_comment_change';
+    this.type = "block_comment_change";
     this.oldContents_ = oldContents;
     this.newContents_ = newContents;
     // Disable undo because Blockly already tracks changes to comment text for
@@ -29,8 +29,8 @@ class BlockCommentChange extends BlockCommentBase {
 
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
-    newEvent.newContents_ = json['newContents'];
-    newEvent.oldContents_ = json['oldContents'];
+    newEvent.newContents_ = json["newContents"];
+    newEvent.oldContents_ = json["oldContents"];
 
     return newEvent;
   }
@@ -38,6 +38,6 @@ class BlockCommentChange extends BlockCommentBase {
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_change',
-  BlockCommentChange,
+  "block_comment_change",
+  BlockCommentChange
 );

--- a/src/events_block_comment_change.js
+++ b/src/events_block_comment_change.js
@@ -1,0 +1,34 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentChange extends BlockCommentBase {
+  constructor(opt_blockComment, oldContents, newContents) {
+    super(opt_blockComment);
+    this.type = 'block_comment_change';
+    this.oldContents_ = oldContents;
+    this.newContents_ = newContents;
+    this.recordUndo = false;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      newContents: this.newContents_,
+      oldContents: this.oldContents_,
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.newContents_ = json['newContents'];
+    newEvent.oldContents_ = json['oldContents'];
+
+    return newEvent;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_change',
+  BlockCommentChange,
+);

--- a/src/events_block_comment_change.js
+++ b/src/events_block_comment_change.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_change.js
+++ b/src/events_block_comment_change.js
@@ -13,6 +13,9 @@ class BlockCommentChange extends BlockCommentBase {
     this.type = 'block_comment_change';
     this.oldContents_ = oldContents;
     this.newContents_ = newContents;
+    // Disable undo because Blockly already tracks changes to comment text for
+    // undo purposes; this event exists solely to keep the Scratch VM apprised
+    // of the state of things.
     this.recordUndo = false;
   }
 

--- a/src/events_block_comment_collapse.js
+++ b/src/events_block_comment_collapse.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentCollapse extends BlockCommentBase {
   constructor(opt_blockComment, collapsed) {
     super(opt_blockComment);
-    this.type = 'block_comment_collapse';
+    this.type = "block_comment_collapse";
     this.newCollapsed = collapsed;
   }
 
@@ -23,13 +23,13 @@ class BlockCommentCollapse extends BlockCommentBase {
 
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
-    newEvent.newCollapsed = json['collapsed'];
+    newEvent.newCollapsed = json["collapsed"];
 
     return newEvent;
   }
 
   run(forward) {
-    const workspace = this.getEventWorkspace_()
+    const workspace = this.getEventWorkspace_();
     const block = workspace.getBlockById(this.blockId);
     const comment = block.getIcon(Blockly.icons.IconType.COMMENT);
     comment.setBubbleVisible(forward ? !this.newCollapsed : this.newCollapsed);
@@ -38,6 +38,6 @@ class BlockCommentCollapse extends BlockCommentBase {
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_collapse',
-  BlockCommentCollapse,
+  "block_comment_collapse",
+  BlockCommentCollapse
 );

--- a/src/events_block_comment_collapse.js
+++ b/src/events_block_comment_collapse.js
@@ -1,0 +1,37 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentCollapse extends BlockCommentBase {
+  constructor(opt_blockComment, collapsed) {
+    super(opt_blockComment);
+    this.type = 'block_comment_collapse';
+    this.newCollapsed = collapsed;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      collapsed: this.newCollapsed,
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.newCollapsed = json['collapsed'];
+
+    return newEvent;
+  }
+
+  run(forward) {
+    const workspace = this.getEventWorkspace_()
+    const block = workspace.getBlockById(this.blockId);
+    const comment = block.getIcon(Blockly.icons.IconType.COMMENT);
+    comment.setBubbleVisible(forward ? !this.newCollapsed : this.newCollapsed);
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_collapse',
+  BlockCommentCollapse,
+);

--- a/src/events_block_comment_collapse.js
+++ b/src/events_block_comment_collapse.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_create.js
+++ b/src/events_block_comment_create.js
@@ -1,0 +1,43 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentCreate extends BlockCommentBase {
+  constructor(opt_blockComment) {
+    super(opt_blockComment);
+    this.type = 'block_comment_create';
+    const size = opt_blockComment.getSize();
+    const location = opt_blockComment.getRelativeToSurfaceXY();
+    this.json = {
+      x: location.x,
+      y: location.y,
+      width: size.width,
+      height: size.height,
+    }
+    this.recordUndo = false;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      json: this.json,
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.json = {
+      x: json['json']['x'],
+      y: json['json']['y'],
+      width: json['json']['width'],
+      height: json['json']['height'],
+    };
+
+    return newEvent;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_create',
+  BlockCommentCreate,
+);

--- a/src/events_block_comment_create.js
+++ b/src/events_block_comment_create.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentCreate extends BlockCommentBase {
   constructor(opt_blockComment) {
     super(opt_blockComment);
-    this.type = 'block_comment_create';
+    this.type = "block_comment_create";
     const size = opt_blockComment.getSize();
     const location = opt_blockComment.getRelativeToSurfaceXY();
     this.json = {
@@ -18,7 +18,7 @@ class BlockCommentCreate extends BlockCommentBase {
       y: location.y,
       width: size.width,
       height: size.height,
-    }
+    };
     // Disable undo because Blockly already tracks comment creation for
     // undo purposes; this event exists solely to keep the Scratch VM apprised
     // of the state of things.
@@ -35,10 +35,10 @@ class BlockCommentCreate extends BlockCommentBase {
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
     newEvent.json = {
-      x: json['json']['x'],
-      y: json['json']['y'],
-      width: json['json']['width'],
-      height: json['json']['height'],
+      x: json["json"]["x"],
+      y: json["json"]["y"],
+      width: json["json"]["width"],
+      height: json["json"]["height"],
     };
 
     return newEvent;
@@ -47,6 +47,6 @@ class BlockCommentCreate extends BlockCommentBase {
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_create',
-  BlockCommentCreate,
+  "block_comment_create",
+  BlockCommentCreate
 );

--- a/src/events_block_comment_create.js
+++ b/src/events_block_comment_create.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_create.js
+++ b/src/events_block_comment_create.js
@@ -19,6 +19,9 @@ class BlockCommentCreate extends BlockCommentBase {
       width: size.width,
       height: size.height,
     }
+    // Disable undo because Blockly already tracks comment creation for
+    // undo purposes; this event exists solely to keep the Scratch VM apprised
+    // of the state of things.
     this.recordUndo = false;
   }
 

--- a/src/events_block_comment_delete.js
+++ b/src/events_block_comment_delete.js
@@ -13,6 +13,9 @@ class BlockCommentDelete extends BlockCommentBase {
     this.type = 'block_comment_delete';
     this.blockId = sourceBlock.id;
     this.workspaceId = sourceBlock.workspace.id;
+    // Disable undo because Blockly already tracks comment deletion for
+    // undo purposes; this event exists solely to keep the Scratch VM apprised
+    // of the state of things.
     this.recordUndo = false;
   }
 }

--- a/src/events_block_comment_delete.js
+++ b/src/events_block_comment_delete.js
@@ -1,0 +1,18 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentDelete extends BlockCommentBase {
+  constructor(opt_blockComment, sourceBlock) {
+    super(opt_blockComment);
+    this.type = 'block_comment_delete';
+    this.blockId = sourceBlock.id;
+    this.workspaceId = sourceBlock.workspace.id;
+    this.recordUndo = false;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_delete',
+  BlockCommentDelete,
+);

--- a/src/events_block_comment_delete.js
+++ b/src/events_block_comment_delete.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_delete.js
+++ b/src/events_block_comment_delete.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentDelete extends BlockCommentBase {
   constructor(opt_blockComment, sourceBlock) {
     super(opt_blockComment);
-    this.type = 'block_comment_delete';
+    this.type = "block_comment_delete";
     this.blockId = sourceBlock.id;
     this.workspaceId = sourceBlock.workspace.id;
     // Disable undo because Blockly already tracks comment deletion for
@@ -22,6 +22,6 @@ class BlockCommentDelete extends BlockCommentBase {
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_delete',
-  BlockCommentDelete,
+  "block_comment_delete",
+  BlockCommentDelete
 );

--- a/src/events_block_comment_move.js
+++ b/src/events_block_comment_move.js
@@ -1,0 +1,48 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentMove extends BlockCommentBase {
+  constructor(opt_blockComment, oldCoordinate, newCoordinate) {
+    super(opt_blockComment);
+    this.type = 'block_comment_move';
+    this.oldCoordinate_ = oldCoordinate;
+    this.newCoordinate_ = newCoordinate;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      newCoordinate: {
+        x: this.newCoordinate_.x,
+        y: this.newCoordinate_.y,
+      },
+      oldCoordinate: {
+        x: this.oldCoordinate_.x,
+        y: this.oldCoordinate_.y,
+      }
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.newCoordinate_ = new Blockly.utils.Coordinate(
+        json['newCoordinate']['x'], json['newCoordinate']['y']);
+    newEvent.oldCoordinate_ = new Blockly.utils.Coordinate(
+        json['oldCoordinate']['x'], json['oldCoordinate']['y']);
+
+    return newEvent;
+  }
+
+  run(forward) {
+    const workspace = this.getEventWorkspace_()
+    const block = workspace?.getBlockById(this.blockId);
+    const comment = block?.getIcon(Blockly.icons.IconType.COMMENT);
+    comment?.setBubbleLocation(forward ? this.newCoordinate_ : this.oldCoordinate_);
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_move',
+  BlockCommentMove,
+);

--- a/src/events_block_comment_move.js
+++ b/src/events_block_comment_move.js
@@ -18,14 +18,8 @@ class BlockCommentMove extends BlockCommentBase {
   toJson() {
     return {
       ...super.toJson(),
-      newCoordinate: {
-        x: this.newCoordinate_.x,
-        y: this.newCoordinate_.y,
-      },
-      oldCoordinate: {
-        x: this.oldCoordinate_.x,
-        y: this.oldCoordinate_.y,
-      },
+      newCoordinate: this.newCoordinate_,
+      oldCoordinate: this.oldCoordinate_,
     };
   }
 

--- a/src/events_block_comment_move.js
+++ b/src/events_block_comment_move.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_move.js
+++ b/src/events_block_comment_move.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentMove extends BlockCommentBase {
   constructor(opt_blockComment, oldCoordinate, newCoordinate) {
     super(opt_blockComment);
-    this.type = 'block_comment_move';
+    this.type = "block_comment_move";
     this.oldCoordinate_ = oldCoordinate;
     this.newCoordinate_ = newCoordinate;
   }
@@ -25,30 +25,36 @@ class BlockCommentMove extends BlockCommentBase {
       oldCoordinate: {
         x: this.oldCoordinate_.x,
         y: this.oldCoordinate_.y,
-      }
+      },
     };
   }
 
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
     newEvent.newCoordinate_ = new Blockly.utils.Coordinate(
-        json['newCoordinate']['x'], json['newCoordinate']['y']);
+      json["newCoordinate"]["x"],
+      json["newCoordinate"]["y"]
+    );
     newEvent.oldCoordinate_ = new Blockly.utils.Coordinate(
-        json['oldCoordinate']['x'], json['oldCoordinate']['y']);
+      json["oldCoordinate"]["x"],
+      json["oldCoordinate"]["y"]
+    );
 
     return newEvent;
   }
 
   run(forward) {
-    const workspace = this.getEventWorkspace_()
+    const workspace = this.getEventWorkspace_();
     const block = workspace?.getBlockById(this.blockId);
     const comment = block?.getIcon(Blockly.icons.IconType.COMMENT);
-    comment?.setBubbleLocation(forward ? this.newCoordinate_ : this.oldCoordinate_);
+    comment?.setBubbleLocation(
+      forward ? this.newCoordinate_ : this.oldCoordinate_
+    );
   }
 }
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_move',
-  BlockCommentMove,
+  "block_comment_move",
+  BlockCommentMove
 );

--- a/src/events_block_comment_resize.js
+++ b/src/events_block_comment_resize.js
@@ -1,0 +1,46 @@
+import * as Blockly from 'blockly/core';
+import {BlockCommentBase} from './events_block_comment_base.js';
+
+class BlockCommentResize extends BlockCommentBase {
+  constructor(opt_blockComment, oldSize, newSize) {
+    super(opt_blockComment);
+    this.type = 'block_comment_resize';
+    this.oldSize = oldSize;
+    this.newSize = newSize;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      newSize: {
+        width: this.newSize.width,
+        height: this.newSize.height,
+      },
+      oldSize: {
+        width: this.oldSize.width,
+        height: this.oldSize.height,
+      }
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.newSize = new Blockly.utils.Size(json['newSize']['width'], json['newSize']['height']);
+    newEvent.oldSize = new Blockly.utils.Size(json['oldSize']['width'], json['oldSize']['height']);
+
+    return newEvent;
+  }
+
+  run(forward) {
+    const workspace = this.getEventWorkspace_()
+    const block = workspace?.getBlockById(this.blockId);
+    const comment = block?.getIcon(Blockly.icons.IconType.COMMENT);
+    comment?.setBubbleSize(forward ? this.newSize : this.oldSize);
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  'block_comment_resize',
+  BlockCommentResize,
+);

--- a/src/events_block_comment_resize.js
+++ b/src/events_block_comment_resize.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {BlockCommentBase} from './events_block_comment_base.js';
+import * as Blockly from "blockly/core";
+import { BlockCommentBase } from "./events_block_comment_base.js";
 
 class BlockCommentResize extends BlockCommentBase {
   constructor(opt_blockComment, oldSize, newSize) {
     super(opt_blockComment);
-    this.type = 'block_comment_resize';
+    this.type = "block_comment_resize";
     this.oldSize = oldSize;
     this.newSize = newSize;
   }
@@ -25,20 +25,26 @@ class BlockCommentResize extends BlockCommentBase {
       oldSize: {
         width: this.oldSize.width,
         height: this.oldSize.height,
-      }
+      },
     };
   }
 
   static fromJson(json, workspace, event) {
     const newEvent = super.fromJson(json, workspace, event);
-    newEvent.newSize = new Blockly.utils.Size(json['newSize']['width'], json['newSize']['height']);
-    newEvent.oldSize = new Blockly.utils.Size(json['oldSize']['width'], json['oldSize']['height']);
+    newEvent.newSize = new Blockly.utils.Size(
+      json["newSize"]["width"],
+      json["newSize"]["height"]
+    );
+    newEvent.oldSize = new Blockly.utils.Size(
+      json["oldSize"]["width"],
+      json["oldSize"]["height"]
+    );
 
     return newEvent;
   }
 
   run(forward) {
-    const workspace = this.getEventWorkspace_()
+    const workspace = this.getEventWorkspace_();
     const block = workspace?.getBlockById(this.blockId);
     const comment = block?.getIcon(Blockly.icons.IconType.COMMENT);
     comment?.setBubbleSize(forward ? this.newSize : this.oldSize);
@@ -47,6 +53,6 @@ class BlockCommentResize extends BlockCommentBase {
 
 Blockly.registry.register(
   Blockly.registry.Type.EVENT,
-  'block_comment_resize',
-  BlockCommentResize,
+  "block_comment_resize",
+  BlockCommentResize
 );

--- a/src/events_block_comment_resize.js
+++ b/src/events_block_comment_resize.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {BlockCommentBase} from './events_block_comment_base.js';
 

--- a/src/events_block_comment_resize.js
+++ b/src/events_block_comment_resize.js
@@ -18,14 +18,8 @@ class BlockCommentResize extends BlockCommentBase {
   toJson() {
     return {
       ...super.toJson(),
-      newSize: {
-        width: this.newSize.width,
-        height: this.newSize.height,
-      },
-      oldSize: {
-        width: this.oldSize.width,
-        height: this.oldSize.height,
-      },
+      newSize: this.newSize,
+      oldSize: this.oldSize,
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,13 @@ import {CheckableContinuousFlyout} from './checkable_continuous_flyout.js';
 import {buildGlowFilter, glowStack} from './glows.js';
 import {ScratchContinuousToolbox} from './scratch_continuous_toolbox.js';
 import './scratch_continuous_category.js';
+import './scratch_comment_icon.js';
+import './events_block_comment_change.js';
+import './events_block_comment_collapse.js';
+import './events_block_comment_create.js';
+import './events_block_comment_delete.js';
+import './events_block_comment_move.js';
+import './events_block_comment_resize.js';
 import {buildShadowFilter} from './shadows.js';
 
 export * from 'blockly';

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -6,6 +6,11 @@
 
 import * as Blockly from 'blockly/core';
 
+/**
+ * A Scratch-style comment bubble for block comments.
+ * @implements {IBubble}
+ * @implements {ISelectable}
+ */
 export class ScratchCommentBubble extends Blockly.comments.CommentView {
   constructor(sourceBlock, anchor) {
     super(sourceBlock.workspace);

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
+import * as Blockly from "blockly/core";
 
 /**
  * A Scratch-style comment bubble for block comments.
@@ -12,43 +12,30 @@ import * as Blockly from 'blockly/core';
  * @implements {ISelectable}
  */
 export class ScratchCommentBubble extends Blockly.comments.CommentView {
-  constructor(sourceBlock, anchor) {
+  constructor(sourceBlock) {
     super(sourceBlock.workspace);
     this.sourceBlock = sourceBlock;
-    this.moveTo(anchor.x + 40, anchor.y - 16);
-    this.anchor = anchor;
     this.disposing = false;
     this.id = Blockly.utils.idGenerator.genUid();
-
-    const location = this.getRelativeToSurfaceXY();
-    this.anchorChain = Blockly.utils.dom.createSvgElement(
-        Blockly.utils.Svg.LINE,
-        {
-          x1: anchor.x,
-          y1: anchor.y,
-          x2: this.getSize().width / 2,
-          y2: 16,
-          style: `stroke: ${sourceBlock.getColourTertiary()}; stroke-width: 1`
-        },
-        this.getSvgRoot());
-    this.getSvgRoot().insertBefore(this.anchorChain, this.getSvgRoot().firstChild);
     this.getSvgRoot().setAttribute(
-        'style', `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`);
+      "style",
+      `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`
+    );
 
     Blockly.browserEvents.conditionalBind(
       this.getSvgRoot(),
-      'pointerdown',
+      "pointerdown",
       this,
-      this.startGesture,
+      this.startGesture
     );
     // Don't zoom with mousewheel; let it scroll instead.
     Blockly.browserEvents.conditionalBind(
       this.getSvgRoot(),
-      'wheel',
+      "wheel",
       this,
       (e) => {
         e.stopPropagation();
-      },
+      }
     );
   }
 
@@ -67,8 +54,10 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
   }
 
   moveTo(xOrCoordinate, y) {
-    const destination = xOrCoordinate instanceof Blockly.utils.Coordinate ?
-        xOrCoordinate : new Blockly.utils.Coordinate(xOrCoordinate, y);
+    const destination =
+      xOrCoordinate instanceof Blockly.utils.Coordinate
+        ? xOrCoordinate
+        : new Blockly.utils.Coordinate(xOrCoordinate, y);
     super.moveTo(destination);
     this.redrawAnchorChain();
   }
@@ -85,7 +74,7 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     this.dragStartLocation = this.getRelativeToSurfaceXY();
     this.workspace.setResizesEnabled(false);
     this.workspace.getLayerManager()?.moveToDragLayer(this);
-    Blockly.utils.dom.addClass(this.getSvgRoot(), 'blocklyDragging');
+    Blockly.utils.dom.addClass(this.getSvgRoot(), "blocklyDragging");
   }
 
   drag(newLocation, event) {
@@ -95,13 +84,13 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
   endDrag() {
     this.workspace.getLayerManager()?.moveOffDragLayer(this, 100);
     this.workspace.setResizesEnabled(false);
-    Blockly.utils.dom.removeClass(this.getSvgRoot(), 'blocklyDragging');
+    Blockly.utils.dom.removeClass(this.getSvgRoot(), "blocklyDragging");
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_move'))(
+      new (Blockly.Events.get("block_comment_move"))(
         this,
         this.dragStartLocation,
-        this.getRelativeToSurfaceXY(),
-      ),
+        this.getRelativeToSurfaceXY()
+      )
     );
   }
 
@@ -110,7 +99,37 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
   }
 
   setAnchorLocation(newAnchor) {
+    const oldAnchor = this.anchor;
+    const alreadyAnchored = !!this.anchor;
     this.anchor = newAnchor;
+    if (!alreadyAnchored) {
+      this.dropAnchor();
+    } else {
+      const oldLocation = this.getRelativeToSurfaceXY();
+      const delta = Blockly.utils.Coordinate.difference(this.anchor, oldAnchor);
+      const newLocation = Blockly.utils.Coordinate.sum(oldLocation, delta);
+      this.moveTo(newLocation);
+    }
+  }
+
+  dropAnchor() {
+    this.moveTo(this.anchor.x + 40, this.anchor.y - 16);
+    const location = this.getRelativeToSurfaceXY();
+    this.anchorChain = Blockly.utils.dom.createSvgElement(
+      Blockly.utils.Svg.LINE,
+      {
+        x1: this.anchor.x,
+        y1: this.anchor.y,
+        x2: this.getSize().width / 2,
+        y2: 16,
+        style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
+      },
+      this.getSvgRoot()
+    );
+    this.getSvgRoot().insertBefore(
+      this.anchorChain,
+      this.getSvgRoot().firstChild
+    );
     this.redrawAnchorChain();
   }
 
@@ -118,8 +137,8 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     if (!this.anchorChain) return;
 
     const location = this.getRelativeToSurfaceXY();
-    this.anchorChain.setAttribute('x1', this.anchor.x - location.x);
-    this.anchorChain.setAttribute('y1', this.anchor.y - location.y);
+    this.anchorChain.setAttribute("x1", this.anchor.x - location.x);
+    this.anchorChain.setAttribute("y1", this.anchor.y - location.y);
   }
 
   getId() {
@@ -135,10 +154,7 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     Blockly.utils.dom.removeNode(this.anchorChain);
     if (this.sourceBlock) {
       Blockly.Events.fire(
-        new (Blockly.Events.get('block_comment_delete'))(
-          this,
-          this.sourceBlock,
-        ),
+        new (Blockly.Events.get("block_comment_delete"))(this, this.sourceBlock)
       );
       const block = this.sourceBlock;
       this.sourceBlock = null;

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -82,7 +82,9 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
   }
 
   endDrag() {
-    this.workspace.getLayerManager()?.moveOffDragLayer(this, 100);
+    this.workspace
+      .getLayerManager()
+      ?.moveOffDragLayer(this, Blockly.layers.BUBBLE);
     this.workspace.setResizesEnabled(false);
     Blockly.utils.dom.removeClass(this.getSvgRoot(), "blocklyDragging");
     Blockly.Events.fire(

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -120,8 +120,8 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     this.anchorChain = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.LINE,
       {
-        x1: this.anchor.x,
-        y1: this.anchor.y,
+        x1: this.anchor.x - location.x,
+        y1: this.anchor.y - location.y,
         x2: this.getSize().width / 2,
         y2: 16,
         style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
@@ -132,7 +132,6 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
       this.anchorChain,
       this.getSvgRoot().firstChild
     );
-    this.redrawAnchorChain();
   }
 
   redrawAnchorChain() {

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -1,0 +1,140 @@
+import * as Blockly from 'blockly/core';
+
+export class ScratchCommentBubble extends Blockly.comments.CommentView {
+  constructor(sourceBlock, anchor) {
+    super(sourceBlock.workspace);
+    this.sourceBlock = sourceBlock;
+    this.moveTo(anchor.x + 40, anchor.y - 16);
+    this.anchor = anchor;
+    this.disposing = false;
+    this.id = Blockly.utils.idGenerator.genUid();
+
+    const location = this.getRelativeToSurfaceXY();
+    this.anchorChain = Blockly.utils.dom.createSvgElement(
+        Blockly.utils.Svg.LINE,
+        {
+          x1: anchor.x,
+          y1: anchor.y,
+          x2: this.getSize().width / 2,
+          y2: 16,
+          style: `stroke: ${sourceBlock.getColourTertiary()}; stroke-width: 1`
+        },
+        this.getSvgRoot());
+    this.getSvgRoot().insertBefore(this.anchorChain, this.getSvgRoot().firstChild);
+    this.getSvgRoot().setAttribute(
+        'style', `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`);
+
+    Blockly.browserEvents.conditionalBind(
+      this.getSvgRoot(),
+      'pointerdown',
+      this,
+      this.startGesture,
+    );
+    // Don't zoom with mousewheel; let it scroll instead.
+    Blockly.browserEvents.conditionalBind(
+      this.getSvgRoot(),
+      'wheel',
+      this,
+      (e) => {
+        e.stopPropagation();
+      },
+    );
+  }
+
+  setDeleteStyle(enable) {}
+  showContextMenu() {}
+  setDragging(start) {}
+  select() {}
+  unselect() {}
+
+  isMovable() {
+    return true;
+  }
+
+  moveDuringDrag(newLocation) {
+    this.moveTo(newLocation);
+  }
+
+  moveTo(xOrCoordinate, y) {
+    const destination = xOrCoordinate instanceof Blockly.utils.Coordinate ?
+        xOrCoordinate : new Blockly.utils.Coordinate(xOrCoordinate, y);
+    super.moveTo(destination);
+    this.redrawAnchorChain();
+  }
+
+  startGesture(e) {
+    const gesture = this.workspace.getGesture(e);
+    if (gesture) {
+      gesture.handleCommentStart(e, this);
+      Blockly.common.setSelected(this);
+    }
+  }
+
+  startDrag(event) {
+    this.dragStartLocation = this.getRelativeToSurfaceXY();
+    this.workspace.setResizesEnabled(false);
+    this.workspace.getLayerManager()?.moveToDragLayer(this);
+    Blockly.utils.dom.addClass(this.getSvgRoot(), 'blocklyDragging');
+  }
+
+  drag(newLocation, event) {
+    this.moveTo(newLocation);
+  }
+
+  endDrag() {
+    this.workspace.getLayerManager()?.moveOffDragLayer(this, 100);
+    this.workspace.setResizesEnabled(false);
+    Blockly.utils.dom.removeClass(this.getSvgRoot(), 'blocklyDragging');
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_move'))(
+        this,
+        this.dragStartLocation,
+        this.getRelativeToSurfaceXY(),
+      ),
+    );
+  }
+
+  revertDrag() {
+    this.moveTo(this.dragStartLocation);
+  }
+
+  setAnchorLocation(newAnchor) {
+    this.anchor = newAnchor;
+    this.redrawAnchorChain();
+  }
+
+  redrawAnchorChain() {
+    if (!this.anchorChain) return;
+
+    const location = this.getRelativeToSurfaceXY();
+    this.anchorChain.setAttribute('x1', this.anchor.x - location.x);
+    this.anchorChain.setAttribute('y1', this.anchor.y - location.y);
+  }
+
+  getId() {
+    return this.id;
+  }
+
+  getSourceBlock() {
+    return this.sourceBlock;
+  }
+
+  dispose() {
+    this.disposing = true;
+    Blockly.utils.dom.removeNode(this.anchorChain);
+    if (this.sourceBlock) {
+      Blockly.Events.fire(
+        new (Blockly.Events.get('block_comment_delete'))(
+          this,
+          this.sourceBlock,
+        ),
+      );
+      const block = this.sourceBlock;
+      this.sourceBlock = null;
+      if (!block.isDeadOrDying()) {
+        block.setCommentText(null);
+      }
+    }
+    super.dispose();
+  }
+}

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 
 export class ScratchCommentBubble extends Blockly.comments.CommentView {

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -1,0 +1,221 @@
+import * as Blockly from 'blockly/core';
+import {ScratchCommentBubble} from './scratch_comment_bubble.js';
+
+class ScratchCommentIcon extends Blockly.icons.Icon {
+  constructor(sourceBlock) {
+    super(sourceBlock);
+    this.sourceBlock = sourceBlock;
+    this.commentBubble = new ScratchCommentBubble(this.sourceBlock, this.getAnchorPoint());
+    Blockly.Events.setGroup(true);
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_create'))(
+        this.commentBubble
+      ),
+    );
+    this.onTextChangedListener = this.onTextChanged.bind(this);
+    this.onSizeChangedListener = this.onSizeChanged.bind(this);
+    this.onCollapseListener = this.onCollapsed.bind(this);
+    this.commentBubble.addTextChangeListener(this.onTextChangedListener);
+    this.commentBubble.addSizeChangeListener(this.onSizeChangedListener);
+    this.commentBubble.addOnCollapseListener(this.onCollapseListener);
+    this.repositionAfterRender = true;
+
+    // We need to force a render of our parent block and wait for it to complete, because at this
+    // point, we don't know our own position (needed to calculate the anchor point and position
+    // the comment bubble properly relative to the block) and our parent block doesn't know if it's
+    // an insertion marker or not (needed to suppress showing the comment bubble attached to an
+    // insertion marker block).
+    this.sourceBlock.queueRender();
+    Blockly.renderManagement.finishQueuedRenders().then(() => {
+      if (!this.sourceBlock || !this.commentBubble) return;
+
+      if (this.sourceBlock.isInsertionMarker()) {
+        this.commentBubble.dispose();
+        return;
+      }
+
+      // loadFromState may have already positioned the bubble appropriately when e.g. populating a
+      // comment from the undo stack. Only position the bubble at the default location if
+      // loadFromState hasn't prohibited repositioning post-render.
+      if (this.repositionAfterRender) {
+        const anchor = this.getAnchorPoint();
+        this.commentBubble.moveTo(anchor.x + 40, anchor.y - 16);
+      }
+      Blockly.Events.setGroup(false);
+    });
+  }
+
+  getType() {
+    return Blockly.icons.IconType.COMMENT;
+  }
+
+  initView(pointerDownListener) {
+    // Scratch comments have no indicator icon on the block.
+    return;
+  }
+
+  getSize() {
+    // Awful hack to cancel out the default padding added to icons.
+    return new Blockly.utils.Size(-8, 0);
+  }
+
+  getAnchorPoint() {
+    const sourceBlockOrigin = this.sourceBlock.getRelativeToSurfaceXY();
+    let left;
+    let right;
+    if (this.sourceBlock.RTL) {
+      left = sourceBlockOrigin.x - this.sourceBlock.width;
+      right = sourceBlockOrigin.x;
+    } else {
+      left = sourceBlockOrigin.x;
+      right = sourceBlockOrigin.x + this.sourceBlock.width;
+    }
+    const blockRect = new Blockly.utils.Rect(
+        sourceBlockOrigin.y, sourceBlockOrigin.y + this.sourceBlock.height, left, right);
+    const y = blockRect.top + this.offsetInBlock.y;
+    const x = this.sourceBlock.workspace.RTL ? blockRect.left : blockRect.right;
+    return new Blockly.utils.Coordinate(x, y);
+  }
+
+  onLocationChange(blockOrigin) {
+    const initialLocation = this.workspaceLocation;
+    super.onLocationChange(blockOrigin);
+    const newLocation = this.workspaceLocation;
+
+    if (this.commentBubble) {
+      const oldBubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
+      const delta = Blockly.utils.Coordinate.difference(newLocation, initialLocation);
+      const newBubbleLocation = Blockly.utils.Coordinate.sum(oldBubbleLocation, delta);
+      this.commentBubble.moveTo(newBubbleLocation);
+      this.commentBubble.setAnchorLocation(this.getAnchorPoint());
+      Blockly.Events.fire(
+        new (Blockly.Events.get('block_comment_move'))(
+          this.commentBubble,
+          oldBubbleLocation,
+          newBubbleLocation,
+        ),
+      );
+    }
+  }
+
+  setText(text) {
+    this.commentBubble?.setText(text);
+  }
+
+  getText() {
+    return this.commentBubble?.getText() ?? '';
+  }
+
+  onTextChanged(oldText, newText) {
+    Blockly.Events.fire(
+      new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
+        this.sourceBlock,
+        'comment',
+        null,
+        oldText,
+        newText,
+      ),
+    );
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_change'))(
+        this.commentBubble,
+        oldText,
+        newText,
+      ),
+    );
+  }
+
+  onCollapsed(collapsed) {
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_collapse'))(
+        this.commentBubble,
+        collapsed,
+      ),
+    );
+  }
+
+  onSizeChanged(oldSize, newSize) {
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_resize'))(
+        this.commentBubble,
+        oldSize,
+        newSize,
+      ),
+    );
+  }
+
+  setBubbleSize(size) {
+    this.commentBubble?.setSize(size);
+  }
+
+  getBubbleSize() {
+    return this.commentBubble?.getSize() ?? new Blockly.utils.Size(0, 0);
+  }
+
+  setBubbleLocation(newLocation) {
+    const oldLocation = this.getBubbleLocation();
+    this.commentBubble?.moveTo(newLocation);
+    Blockly.Events.fire(
+      new (Blockly.Events.get('block_comment_move'))(
+        this.commentBubble,
+        oldLocation,
+        newLocation,
+      ),
+    );
+  }
+
+  getBubbleLocation() {
+    return this.commentBubble?.getRelativeToSurfaceXY();
+  }
+
+  saveState() {
+    if (this.commentBubble) {
+      const size = this.getBubbleSize();
+      const bubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
+      const delta = Blockly.utils.Coordinate.difference(bubbleLocation, this.workspaceLocation);
+      return {
+        'text': this.getText(),
+        'height': size.height,
+        'width': size.width,
+        'x': delta.x,
+        'y': delta.y,
+        'collapsed': this.commentBubble.isCollapsed(),
+      }
+    }
+    return null;
+  }
+
+  loadState(state) {
+    this.setText(state['text']);
+    this.setBubbleSize(new Blockly.utils.Size(state['width'], state['height']));
+    const delta = new Blockly.utils.Coordinate(state['x'], state['y']);
+    const newBubbleLocation = Blockly.utils.Coordinate.sum(this.workspaceLocation, delta);
+    this.commentBubble.moveTo(newBubbleLocation);
+    this.commentBubble.setCollapsed(state['collapsed']);
+    this.repositionAfterRender = false;
+  }
+
+  bubbleIsVisible() {
+    return true;
+  }
+
+  async setBubbleVisible(visible) {
+    this.commentBubble.setCollapsed(!visible);
+  }
+
+  dispose() {
+    this.commentBubble?.removeTextChangeListener(this.onTextChangedListener);
+    this.commentBubble?.removeSizeChangeListener(this.onSizeChangedListener);
+    this.commentBubble?.removeOnCollapseListener(this.onCollapseListener);
+    this.commentBubble?.dispose();
+    this.commentBubble = null;
+    this.sourceBlock = null;
+    super.dispose();
+  }
+}
+
+Blockly.registry.register(
+    Blockly.registry.Type.ICON,
+    Blockly.icons.IconType.COMMENT.toString(),
+    ScratchCommentIcon,
+    true);

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {ScratchCommentBubble} from './scratch_comment_bubble.js';
+import * as Blockly from "blockly/core";
+import { ScratchCommentBubble } from "./scratch_comment_bubble.js";
 
 /**
  * Custom comment icon that draws no icon indicator, used for block comments.
@@ -16,12 +16,13 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   constructor(sourceBlock) {
     super(sourceBlock);
     this.sourceBlock = sourceBlock;
-    this.commentBubble = new ScratchCommentBubble(this.sourceBlock, this.getAnchorPoint());
+    this.commentBubble = new ScratchCommentBubble(
+      this.sourceBlock,
+      this.getAnchorPoint()
+    );
     Blockly.Events.setGroup(true);
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_create'))(
-        this.commentBubble
-      ),
+      new (Blockly.Events.get("block_comment_create"))(this.commentBubble)
     );
     this.onTextChangedListener = this.onTextChanged.bind(this);
     this.onSizeChangedListener = this.onSizeChanged.bind(this);
@@ -82,7 +83,11 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
       right = sourceBlockOrigin.x + this.sourceBlock.width;
     }
     const blockRect = new Blockly.utils.Rect(
-        sourceBlockOrigin.y, sourceBlockOrigin.y + this.sourceBlock.height, left, right);
+      sourceBlockOrigin.y,
+      sourceBlockOrigin.y + this.sourceBlock.height,
+      left,
+      right
+    );
     const y = blockRect.top + this.offsetInBlock.y;
     const x = this.sourceBlock.workspace.RTL ? blockRect.left : blockRect.right;
     return new Blockly.utils.Coordinate(x, y);
@@ -95,16 +100,22 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
 
     if (this.commentBubble) {
       const oldBubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
-      const delta = Blockly.utils.Coordinate.difference(newLocation, initialLocation);
-      const newBubbleLocation = Blockly.utils.Coordinate.sum(oldBubbleLocation, delta);
+      const delta = Blockly.utils.Coordinate.difference(
+        newLocation,
+        initialLocation
+      );
+      const newBubbleLocation = Blockly.utils.Coordinate.sum(
+        oldBubbleLocation,
+        delta
+      );
       this.commentBubble.moveTo(newBubbleLocation);
       this.commentBubble.setAnchorLocation(this.getAnchorPoint());
       Blockly.Events.fire(
-        new (Blockly.Events.get('block_comment_move'))(
+        new (Blockly.Events.get("block_comment_move"))(
           this.commentBubble,
           oldBubbleLocation,
-          newBubbleLocation,
-        ),
+          newBubbleLocation
+        )
       );
     }
   }
@@ -114,44 +125,44 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   }
 
   getText() {
-    return this.commentBubble?.getText() ?? '';
+    return this.commentBubble?.getText() ?? "";
   }
 
   onTextChanged(oldText, newText) {
     Blockly.Events.fire(
       new (Blockly.Events.get(Blockly.Events.BLOCK_CHANGE))(
         this.sourceBlock,
-        'comment',
+        "comment",
         null,
         oldText,
-        newText,
-      ),
+        newText
+      )
     );
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_change'))(
+      new (Blockly.Events.get("block_comment_change"))(
         this.commentBubble,
         oldText,
-        newText,
-      ),
+        newText
+      )
     );
   }
 
   onCollapsed(collapsed) {
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_collapse'))(
+      new (Blockly.Events.get("block_comment_collapse"))(
         this.commentBubble,
-        collapsed,
-      ),
+        collapsed
+      )
     );
   }
 
   onSizeChanged(oldSize, newSize) {
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_resize'))(
+      new (Blockly.Events.get("block_comment_resize"))(
         this.commentBubble,
         oldSize,
-        newSize,
-      ),
+        newSize
+      )
     );
   }
 
@@ -167,11 +178,11 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
     const oldLocation = this.getBubbleLocation();
     this.commentBubble?.moveTo(newLocation);
     Blockly.Events.fire(
-      new (Blockly.Events.get('block_comment_move'))(
+      new (Blockly.Events.get("block_comment_move"))(
         this.commentBubble,
         oldLocation,
-        newLocation,
-      ),
+        newLocation
+      )
     );
   }
 
@@ -184,24 +195,30 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
 
     const size = this.getBubbleSize();
     const bubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
-    const delta = Blockly.utils.Coordinate.difference(bubbleLocation, this.workspaceLocation);
+    const delta = Blockly.utils.Coordinate.difference(
+      bubbleLocation,
+      this.workspaceLocation
+    );
     return {
-      'text': this.getText(),
-      'height': size.height,
-      'width': size.width,
-      'x': delta.x,
-      'y': delta.y,
-      'collapsed': this.commentBubble.isCollapsed(),
+      text: this.getText(),
+      height: size.height,
+      width: size.width,
+      x: delta.x,
+      y: delta.y,
+      collapsed: this.commentBubble.isCollapsed(),
     };
   }
 
   loadState(state) {
-    this.setText(state['text']);
-    this.setBubbleSize(new Blockly.utils.Size(state['width'], state['height']));
-    const delta = new Blockly.utils.Coordinate(state['x'], state['y']);
-    const newBubbleLocation = Blockly.utils.Coordinate.sum(this.workspaceLocation, delta);
+    this.setText(state["text"]);
+    this.setBubbleSize(new Blockly.utils.Size(state["width"], state["height"]));
+    const delta = new Blockly.utils.Coordinate(state["x"], state["y"]);
+    const newBubbleLocation = Blockly.utils.Coordinate.sum(
+      this.workspaceLocation,
+      delta
+    );
     this.commentBubble.moveTo(newBubbleLocation);
-    this.commentBubble.setCollapsed(state['collapsed']);
+    this.commentBubble.setCollapsed(state["collapsed"]);
     this.repositionAfterRender = false;
   }
 
@@ -222,7 +239,8 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.ICON,
-    Blockly.icons.IconType.COMMENT.toString(),
-    ScratchCommentIcon,
-    true);
+  Blockly.registry.Type.ICON,
+  Blockly.icons.IconType.COMMENT.toString(),
+  ScratchCommentIcon,
+  true
+);

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -7,6 +7,11 @@
 import * as Blockly from 'blockly/core';
 import {ScratchCommentBubble} from './scratch_comment_bubble.js';
 
+/**
+ * Custom comment icon that draws no icon indicator, used for block comments.
+ * @implements {IHasBubble}
+ * @implements {ISerializable}
+ */
 class ScratchCommentIcon extends Blockly.icons.Icon {
   constructor(sourceBlock) {
     super(sourceBlock);

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from 'blockly/core';
 import {ScratchCommentBubble} from './scratch_comment_bubble.js';
 

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -215,9 +215,6 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   }
 
   dispose() {
-    this.commentBubble?.removeTextChangeListener(this.onTextChangedListener);
-    this.commentBubble?.removeSizeChangeListener(this.onSizeChangedListener);
-    this.commentBubble?.removeOnCollapseListener(this.onCollapseListener);
     this.commentBubble?.dispose();
     this.commentBubble = null;
     this.sourceBlock = null;

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -180,20 +180,19 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   }
 
   saveState() {
-    if (this.commentBubble) {
-      const size = this.getBubbleSize();
-      const bubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
-      const delta = Blockly.utils.Coordinate.difference(bubbleLocation, this.workspaceLocation);
-      return {
-        'text': this.getText(),
-        'height': size.height,
-        'width': size.width,
-        'x': delta.x,
-        'y': delta.y,
-        'collapsed': this.commentBubble.isCollapsed(),
-      }
-    }
-    return null;
+    if (!this.commentBubble) return null;
+
+    const size = this.getBubbleSize();
+    const bubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
+    const delta = Blockly.utils.Coordinate.difference(bubbleLocation, this.workspaceLocation);
+    return {
+      'text': this.getText(),
+      'height': size.height,
+      'width': size.width,
+      'x': delta.x,
+      'y': delta.y,
+      'collapsed': this.commentBubble.isCollapsed(),
+    };
   }
 
   loadState(state) {

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -16,10 +16,7 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   constructor(sourceBlock) {
     super(sourceBlock);
     this.sourceBlock = sourceBlock;
-    this.commentBubble = new ScratchCommentBubble(
-      this.sourceBlock,
-      this.getAnchorPoint()
-    );
+    this.commentBubble = new ScratchCommentBubble(this.sourceBlock);
     Blockly.Events.fire(
       new (Blockly.Events.get("block_comment_create"))(this.commentBubble)
     );
@@ -29,7 +26,6 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
     this.commentBubble.addTextChangeListener(this.onTextChangedListener);
     this.commentBubble.addSizeChangeListener(this.onSizeChangedListener);
     this.commentBubble.addOnCollapseListener(this.onCollapseListener);
-    this.repositionAfterRender = true;
   }
 
   getType() {
@@ -76,35 +72,10 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
       return;
     }
 
-    const initialLocation = this.workspaceLocation;
     super.onLocationChange(blockOrigin);
-    const newLocation = this.workspaceLocation;
-
     const oldBubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
-    let newBubbleLocation;
-    // If repositionAfterRender is set, move the bubble to its default offset
-    // relative to the block; otherwise, preserve the bubble's existing relative
-    // offset to the block.
-    if (this.repositionAfterRender) {
-      const anchor = this.getAnchorPoint();
-      newBubbleLocation = new Blockly.utils.Coordinate(
-        anchor.x + 40,
-        anchor.y - 16
-      );
-      this.repositionAfterRender = false;
-    } else {
-      const delta = Blockly.utils.Coordinate.difference(
-        newLocation,
-        initialLocation
-      );
-      newBubbleLocation = Blockly.utils.Coordinate.sum(
-        oldBubbleLocation,
-        delta
-      );
-    }
-
-    this.commentBubble.moveTo(newBubbleLocation);
     this.commentBubble.setAnchorLocation(this.getAnchorPoint());
+    const newBubbleLocation = this.commentBubble.getRelativeToSurfaceXY();
     Blockly.Events.fire(
       new (Blockly.Events.get("block_comment_move"))(
         this.commentBubble,
@@ -213,7 +184,6 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
     );
     this.commentBubble.moveTo(newBubbleLocation);
     this.commentBubble.setCollapsed(state["collapsed"]);
-    this.repositionAfterRender = false;
   }
 
   bubbleIsVisible() {

--- a/src/scratch_comment_icon.js
+++ b/src/scratch_comment_icon.js
@@ -43,22 +43,7 @@ class ScratchCommentIcon extends Blockly.icons.Icon {
   }
 
   getAnchorPoint() {
-    const sourceBlockOrigin = this.sourceBlock.getRelativeToSurfaceXY();
-    let left;
-    let right;
-    if (this.sourceBlock.RTL) {
-      left = sourceBlockOrigin.x - this.sourceBlock.width;
-      right = sourceBlockOrigin.x;
-    } else {
-      left = sourceBlockOrigin.x;
-      right = sourceBlockOrigin.x + this.sourceBlock.width;
-    }
-    const blockRect = new Blockly.utils.Rect(
-      sourceBlockOrigin.y,
-      sourceBlockOrigin.y + this.sourceBlock.height,
-      left,
-      right
-    );
+    const blockRect = this.sourceBlock.getBoundingRectangleWithoutChildren();
     const y = blockRect.top + this.offsetInBlock.y;
     const x = this.sourceBlock.workspace.RTL ? blockRect.left : blockRect.right;
     return new Blockly.utils.Coordinate(x, y);


### PR DESCRIPTION
This PR adds support for Scratch-style block comments. These use the same look and feel as workspace comments, but are visually attached to their parent block by a line.

A new bubble, inheriting from the CommentView also used by workspace comments, is paired with a custom comment icon that replaces Blockly's built-in version. Additionally, custom events for all block comment actions (create, delete, modify, move, resize, collapse) are added and fired as needed, in order to keep the VM apprised of the state of the comments to allow it to properly serialize the project state when saving. The create, delete, and modify events are not undoable, because Blockly already handles undo support for those mutations via BlockChange events.

This fixes #3.