### PR TITLE
feat: add custom Scratch variable model and creation event classes

### DIFF
--- a/src/events_scratch_variable_create.js
+++ b/src/events_scratch_variable_create.js
@@ -1,0 +1,16 @@
+import * as Blockly from "blockly/core";
+
+class ScratchVariableCreate extends Blockly.Events.VarCreate {
+  constructor(variable) {
+    super(variable);
+    this.isLocal = variable.isLocal;
+    this.isCloud = variable.isCloud;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.EVENT,
+  Blockly.Events.VAR_CREATE,
+  ScratchVariableCreate,
+  true
+);

--- a/src/events_scratch_variable_create.js
+++ b/src/events_scratch_variable_create.js
@@ -3,8 +3,52 @@ import * as Blockly from "blockly/core";
 class ScratchVariableCreate extends Blockly.Events.VarCreate {
   constructor(variable) {
     super(variable);
+    if (!variable) return;
+
     this.isLocal = variable.isLocal;
     this.isCloud = variable.isCloud;
+  }
+
+  toJson() {
+    const json = super.toJson();
+    json["isLocal"] = this.isLocal;
+    json["isCloud"] = this.isCloud;
+    return json;
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.isLocal = json["isLocal"];
+    newEvent.isCloud = json["isCloud"];
+    return newEvent;
+  }
+
+  run(forward) {
+    const workspace = this.getEventWorkspace_();
+    if (forward) {
+      const VariableModel = Blockly.registry.getObject(
+        Blockly.registry.Type.VARIABLE_MODEL,
+        Blockly.registry.DEFAULT,
+        true
+      );
+      const variable = new VariableModel(
+        workspace,
+        this.varName,
+        this.varType,
+        this.varId,
+        this.isLocal,
+        this.isCloud
+      );
+      workspace.getVariableMap().addVariable(variable);
+      Blockly.Events.fire(
+        new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(variable)
+      );
+    } else {
+      const variable = workspace.getVariableMap().getVariableById(this.varId);
+      if (variable) {
+        workspace.getVariableMap().deleteVariable(variable);
+      }
+    }
   }
 }
 

--- a/src/events_scratch_variable_create.js
+++ b/src/events_scratch_variable_create.js
@@ -31,6 +31,7 @@ class ScratchVariableCreate extends Blockly.Events.VarCreate {
 
   run(forward) {
     const workspace = this.getEventWorkspace_();
+    const variableMap = workspace.getVariableMap();
     if (forward) {
       const VariableModel = Blockly.registry.getObject(
         Blockly.registry.Type.VARIABLE_MODEL,
@@ -45,14 +46,14 @@ class ScratchVariableCreate extends Blockly.Events.VarCreate {
         this.isLocal,
         this.isCloud
       );
-      workspace.getVariableMap().addVariable(variable);
+      variableMap.addVariable(variable);
       Blockly.Events.fire(
         new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(variable)
       );
     } else {
-      const variable = workspace.getVariableMap().getVariableById(this.varId);
+      const variable = variableMap.getVariableById(this.varId);
       if (variable) {
-        workspace.getVariableMap().deleteVariable(variable);
+        variableMap.deleteVariable(variable);
       }
     }
   }

--- a/src/events_scratch_variable_create.js
+++ b/src/events_scratch_variable_create.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from "blockly/core";
 
 class ScratchVariableCreate extends Blockly.Events.VarCreate {

--- a/src/index.js
+++ b/src/index.js
@@ -4,58 +4,58 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
-import {registerFieldAngle} from '@blockly/field-angle';
+import * as Blockly from "blockly/core";
+import { registerFieldAngle } from "@blockly/field-angle";
 registerFieldAngle();
-import '../blocks_common/colour.js';
-import '../blocks_common/math.js';
-import '../blocks_common/matrix.js';
-import '../blocks_common/note.js';
-import '../blocks_common/text.js';
-import '../blocks_vertical/vertical_extensions.js';
-import '../blocks_vertical/control.js';
-import '../blocks_vertical/data.js';
-import '../blocks_vertical/event.js';
-import '../blocks_vertical/looks.js';
-import '../blocks_vertical/motion.js';
-import '../blocks_vertical/operators.js';
-import '../blocks_vertical/procedures.js';
-import '../blocks_vertical/sensing.js';
-import '../blocks_vertical/sound.js';
-import * as scratchBlocksUtils from '../core/scratch_blocks_utils.js';
-import '../core/css.js';
-import '../core/field_vertical_separator.js';
+import "../blocks_common/colour.js";
+import "../blocks_common/math.js";
+import "../blocks_common/matrix.js";
+import "../blocks_common/note.js";
+import "../blocks_common/text.js";
+import "../blocks_vertical/vertical_extensions.js";
+import "../blocks_vertical/control.js";
+import "../blocks_vertical/data.js";
+import "../blocks_vertical/event.js";
+import "../blocks_vertical/looks.js";
+import "../blocks_vertical/motion.js";
+import "../blocks_vertical/operators.js";
+import "../blocks_vertical/procedures.js";
+import "../blocks_vertical/sensing.js";
+import "../blocks_vertical/sound.js";
+import * as scratchBlocksUtils from "../core/scratch_blocks_utils.js";
+import "../core/css.js";
+import "../core/field_vertical_separator.js";
 import {
   ContinuousToolbox,
   ContinuousFlyout,
   ContinuousMetrics,
-} from '@blockly/continuous-toolbox';
-import {CheckableContinuousFlyout} from './checkable_continuous_flyout.js';
-import {buildGlowFilter, glowStack} from './glows.js';
-import {ScratchContinuousToolbox} from './scratch_continuous_toolbox.js';
-import './scratch_continuous_category.js';
-import './scratch_comment_icon.js';
-import './events_block_comment_change.js';
-import './events_block_comment_collapse.js';
-import './events_block_comment_create.js';
-import './events_block_comment_delete.js';
-import './events_block_comment_move.js';
-import './events_block_comment_resize.js';
-import {buildShadowFilter} from './shadows.js';
+} from "@blockly/continuous-toolbox";
+import { CheckableContinuousFlyout } from "./checkable_continuous_flyout.js";
+import { buildGlowFilter, glowStack } from "./glows.js";
+import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
+import "./scratch_continuous_category.js";
+import "./scratch_comment_icon.js";
+import "./events_block_comment_change.js";
+import "./events_block_comment_collapse.js";
+import "./events_block_comment_create.js";
+import "./events_block_comment_delete.js";
+import "./events_block_comment_move.js";
+import "./events_block_comment_resize.js";
+import { buildShadowFilter } from "./shadows.js";
 
-export * from 'blockly';
-export * from './block_reporting.js';
-export * from './categories.js';
-export * from './procedures.js';
-export * from '../core/colours.js';
-export * from '../core/field_colour_slider.js';
-export * from '../core/field_matrix.js';
-export * from '../core/field_note.js';
-export * from '../core/field_number.js';
-export * from '../msg/scratch_msgs.js';
-export {glowStack};
-export {scratchBlocksUtils};
-export {CheckableContinuousFlyout};
+export * from "blockly";
+export * from "./block_reporting.js";
+export * from "./categories.js";
+export * from "./procedures.js";
+export * from "../core/colours.js";
+export * from "../core/field_colour_slider.js";
+export * from "../core/field_matrix.js";
+export * from "../core/field_note.js";
+export * from "../core/field_number.js";
+export * from "../msg/scratch_msgs.js";
+export { glowStack };
+export { scratchBlocksUtils };
+export { CheckableContinuousFlyout };
 
 export function inject(container, options) {
   Object.assign(options, {
@@ -66,11 +66,12 @@ export function inject(container, options) {
     },
   });
   const workspace = Blockly.inject(container, options);
-  workspace.getRenderer().getConstants().selectedGlowFilterId = '';
+  workspace.getRenderer().getConstants().selectedGlowFilterId = "";
 
   const flyout = workspace.getFlyout();
   if (flyout) {
-    flyout.getWorkspace().getRenderer().getConstants().selectedGlowFilterId = '';
+    flyout.getWorkspace().getRenderer().getConstants().selectedGlowFilterId =
+      "";
   }
 
   buildGlowFilter(workspace);
@@ -88,6 +89,6 @@ export function inject(container, options) {
 Blockly.Scrollbar.scrollbarThickness = Blockly.Touch.TOUCH_ENABLED ? 14 : 11;
 Blockly.FlyoutButton.TEXT_MARGIN_X = 40;
 Blockly.FlyoutButton.TEXT_MARGIN_Y = 10;
-Blockly.ContextMenuRegistry.registry.unregister('blockDisable');
-Blockly.ContextMenuRegistry.registry.unregister('blockInline');
+Blockly.ContextMenuRegistry.registry.unregister("blockDisable");
+Blockly.ContextMenuRegistry.registry.unregister("blockInline");
 Blockly.ContextMenuItems.registerCommentOptions();

--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,14 @@ import { buildGlowFilter, glowStack } from "./glows.js";
 import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
 import "./scratch_continuous_category.js";
 import "./scratch_comment_icon.js";
+import "./scratch_variable_model.js";
 import "./events_block_comment_change.js";
 import "./events_block_comment_collapse.js";
 import "./events_block_comment_create.js";
 import "./events_block_comment_delete.js";
 import "./events_block_comment_move.js";
 import "./events_block_comment_resize.js";
+import "./events_scratch_variable_create.js";
 import { buildShadowFilter } from "./shadows.js";
 
 export * from "blockly";

--- a/src/scratch_variable_model.js
+++ b/src/scratch_variable_model.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as Blockly from "blockly/core";
 
 class ScratchVariableModel extends Blockly.VariableModel {

--- a/src/scratch_variable_model.js
+++ b/src/scratch_variable_model.js
@@ -1,0 +1,18 @@
+import * as Blockly from "blockly/core";
+
+class ScratchVariableModel extends Blockly.VariableModel {
+  constructor(workspace, name, type, id, isLocal, isCloud) {
+    super(workspace, name, type, id);
+    // isLocal and isCloud may not be passed when creating broadcast message
+    // variables, which conveniently are neither local nor cloud.
+    this.isLocal = !!isLocal;
+    this.isCloud = !!isCloud;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.VARIABLE_MODEL,
+  Blockly.registry.DEFAULT,
+  ScratchVariableModel,
+  true
+);


### PR DESCRIPTION
This PR adds a custom variable model and variable creation event that both record the `isLocal` and `isCloud` fields used by the Scratch VM to identify per-sprite/global and cloud variables. This fixes part of #9.