### PR TITLE
fix: allow specifying the function to be used for prompting about variable creation/edits

### DIFF
--- a/src/variables.js
+++ b/src/variables.js
@@ -37,6 +37,12 @@ import {
  */
 const CLOUD_PREFIX = "☁ ";
 
+let prompt = null;
+
+export function setPromptHandler(handler) {
+  prompt = handler;
+}
+
 /**
  * Create a new variable on the given workspace.
  * @param {!Blockly.Workspace} workspace The workspace on which to create the
@@ -70,7 +76,7 @@ export function createVariable(workspace, opt_callback, opt_type) {
   var validate = nameValidator.bind(null, opt_type);
 
   // Prompt the user to enter a name for the variable
-  Blockly.dialog.prompt(
+  prompt(
     newMsg,
     "",
     function (text, additionalVars, variableOptions) {
@@ -309,7 +315,7 @@ export function renameVariable(workspace, variable, opt_callback) {
     promptDefaultText = promptDefaultText.substring(CLOUD_PREFIX.length);
   }
 
-  Blockly.dialog.prompt(
+  prompt(
     promptText,
     promptDefaultText,
     function (newName, additionalVars) {


### PR DESCRIPTION
This PR allows scratch-gui to specify the function that the variables implementation should use to prompt the user about creating/renaming variables. The corresponding change in scratch-gui is here: https://github.com/gonfunko/scratch-gui/pull/17