### PR TITLE
fix: prevent dragging blocks into the slot occupied by the procedure definition block's example caller block

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
 import "./scratch_continuous_category.js";
 import "./scratch_comment_icon.js";
 import "./scratch_variable_model.js";
+import "./scratch_connection_checker.js";
 import "./events_block_comment_change.js";
 import "./events_block_comment_collapse.js";
 import "./events_block_comment_create.js";

--- a/src/scratch_connection_checker.js
+++ b/src/scratch_connection_checker.js
@@ -14,8 +14,6 @@ class ScratchConnectionChecker extends Blockly.ConnectionChecker {
       b.getSourceBlock().type === "procedures_definition" &&
       b.getParentInput()?.name === "custom_block"
     ) {
-      console.log("disallow");
-      console.log(b.type);
       return false;
     }
 

--- a/src/scratch_connection_checker.js
+++ b/src/scratch_connection_checker.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+class ScratchConnectionChecker extends Blockly.ConnectionChecker {
+  // This check prevents dragging a block into the slot occupied by the
+  // procedure caller example block in a procedure definition block.
+  doDragChecks(a, b, distance) {
+    if (
+      b.getSourceBlock().type === "procedures_definition" &&
+      b.getParentInput()?.name === "custom_block"
+    ) {
+      console.log("disallow");
+      console.log(b.type);
+      return false;
+    }
+
+    return super.doDragChecks(a, b, distance);
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.CONNECTION_CHECKER,
+  Blockly.registry.DEFAULT,
+  ScratchConnectionChecker,
+  true
+);


### PR DESCRIPTION
This PR resolves #116 by adding a custom connection checker that prohibits dragging blocks into the input occupied by the example caller block in a procedure definition block.