### PR TITLE
fix: prevent deleting procedure definition blocks with references by dragging to the flyout

### DIFF
--- a/src/scratch_dragger.js
+++ b/src/scratch_dragger.js
@@ -10,6 +10,27 @@ class ScratchDragger extends Blockly.dragging.Dragger {
   setDraggable(draggable) {
     this.draggable = draggable;
   }
+
+  onDragEnd(event) {
+    if (
+      this.draggable instanceof Blockly.BlockSvg &&
+      this.draggable.type === "procedures_definition"
+    ) {
+      const procCode = this.draggable
+        .getInputTargetBlock("custom_block")
+        .getProcCode();
+      const hasCaller = this.workspace
+        .getBlocksByType("procedures_call")
+        .some((b) => b.getProcCode() === procCode);
+      if (hasCaller) {
+        Blockly.dialog.alert(Blockly.Msg.PROCEDURE_USED);
+        this.draggable.revertDrag();
+        this.draggable.endDrag();
+        return;
+      }
+    }
+    super.onDragEnd(event);
+  }
 }
 
 Blockly.registry.register(


### PR DESCRIPTION
This PR fixes a bug whereby procedure definition blocks with callers on the workspace could be deleted by dragging them to the flyout. Now, the user will be prompted to remove the callers first, just like deleting the definition block via the contextual menu.