### PR TITLE
fix: make variable names case-sensitive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
 import "./scratch_continuous_category.js";
 import "./scratch_comment_icon.js";
 import "./scratch_dragger.js";
+import "./scratch_variable_map.js";
 import "./scratch_variable_model.js";
 import "./scratch_connection_checker.js";
 import "./events_block_comment_change.js";

--- a/src/scratch_variable_map.js
+++ b/src/scratch_variable_map.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+class ScratchVariableMap extends Blockly.VariableMap {
+  getVariable(name, type) {
+    // Variable names in Blockly are case-insensitive, but case sensitive in
+    // Scratch. Override the implementation to only return a variable whose name
+    // is identical to the one requested.
+    const variables = this.getVariablesOfType(type ?? "");
+    if (!variables.length) return null;
+    return variables.find((v) => v.getName() === name) ?? null;
+  }
+}
+
+Blockly.registry.register(
+  Blockly.registry.Type.VARIABLE_MAP,
+  Blockly.registry.DEFAULT,
+  ScratchVariableMap,
+  true
+);


### PR DESCRIPTION
This PR allows users to create variables whose names differ only in case. This fixes #96.