### PR TITLE
fix: don't show global/local options when renaming a variable

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -58,3 +58,10 @@ export { OUTPUT_SHAPE_ROUND };
  */
 const NEW_BROADCAST_MESSAGE_ID = "NEW_BROADCAST_MESSAGE_ID";
 export { NEW_BROADCAST_MESSAGE_ID };
+
+/**
+ * String for use in the dropdown created in field_variable.
+ * This string indicates that this option in the dropdown is 'Rename
+ * variable...' and if selected, should trigger the prompt to rename a variable.
+ */
+export const RENAME_VARIABLE_ID = "RENAME_VARIABLE_ID";

--- a/src/field_variable.js
+++ b/src/field_variable.js
@@ -25,7 +25,7 @@
 import * as Blockly from "blockly/core";
 import * as Constants from "./constants.js";
 import { ScratchMsgs } from "../msg/scratch_msgs.js";
-import { createVariable } from "./variables.js";
+import { createVariable, renameVariable } from "./variables.js";
 
 class FieldVariable extends Blockly.FieldVariable {
   constructor(varName, validator, variableTypes, defaultType, config) {
@@ -115,21 +115,23 @@ class FieldVariable extends Blockly.FieldVariable {
    */
   onItemSelected_(menu, menuItem) {
     const sourceBlock = this.getSourceBlock();
-    if (
-      sourceBlock &&
-      !sourceBlock.isDeadOrDying() &&
-      menuItem.getValue() === Constants.NEW_BROADCAST_MESSAGE_ID
-    ) {
-      createVariable(
-        sourceBlock.workspace,
-        (varId) => {
-          if (varId) {
-            this.setValue(varId);
-          }
-        },
-        Constants.BROADCAST_MESSAGE_VARIABLE_TYPE
-      );
-      return;
+    if (sourceBlock && !sourceBlock.isDeadOrDying()) {
+      const selectedItem = menuItem.getValue();
+      if (selectedItem === Constants.NEW_BROADCAST_MESSAGE_ID) {
+        createVariable(
+          sourceBlock.workspace,
+          (varId) => {
+            if (varId) {
+              this.setValue(varId);
+            }
+          },
+          Constants.BROADCAST_MESSAGE_VARIABLE_TYPE
+        );
+        return;
+      } else if (selectedItem === Constants.RENAME_VARIABLE_ID) {
+        renameVariable(sourceBlock.workspace, this.variable);
+        return;
+      }
     }
     super.onItemSelected_(menu, menuItem);
   }


### PR DESCRIPTION
This PR fixes a bug where the "For all sprites" and "For this sprite only" radio buttons were incorrectly shown when renaming a variable.