### PR TITLE
fix: fix bug where user would be prompted to confirm deletion of variable blocks in the flyout

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -65,3 +65,10 @@ export { NEW_BROADCAST_MESSAGE_ID };
  * variable...' and if selected, should trigger the prompt to rename a variable.
  */
 export const RENAME_VARIABLE_ID = "RENAME_VARIABLE_ID";
+
+/**
+ * String for use in the dropdown created in field_variable.
+ * This string indicates that this option in the dropdown is 'Delete the "%1"
+ * variable' and if selected, should trigger the prompt to delete a variable.
+ */
+export const DELETE_VARIABLE_ID = "DELETE_VARIABLE_ID";

--- a/src/field_variable.js
+++ b/src/field_variable.js
@@ -131,6 +131,12 @@ class FieldVariable extends Blockly.FieldVariable {
       } else if (selectedItem === Constants.RENAME_VARIABLE_ID) {
         renameVariable(sourceBlock.workspace, this.variable);
         return;
+      } else if (selectedItem === Constants.DELETE_VARIABLE_ID) {
+        Blockly.Variables.deleteVariable(
+          this.variable.getWorkspace(),
+          this.variable
+        );
+        return;
       }
     }
     super.onItemSelected_(menu, menuItem);


### PR DESCRIPTION
This PR fixes a bug where deleting a variable via the "Delete the 'X' variable" menu item in the variable dropdown field of a block in the flyout would ask the user to confirm the deletion of the 5 other uses of that variable, ie the other variable-related blocks in the flyout. Now, the user will only be prompted to confirm the deletion of uses of the variable in the main workspace.