### PR TITLE
fix: add zoom controls config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,12 @@ export function inject(container, options) {
   Object.assign(options, {
     renderer: "scratch",
     theme: "zelos",
+    zoom: {
+      controls: true,
+      wheel: true,
+      pinch: true,
+      startScale: 0.675,
+    },
     plugins: {
       toolbox: ScratchContinuousToolbox,
       flyoutsVerticalToolbox: CheckableContinuousFlyout,


### PR DESCRIPTION
### Resolves

Fixes https://github.com/gonfunko/scratch-blocks/issues/67

### Proposed Changes

Makes it so that pinch-to-zoom works.


### Test Coverage

Funnily enough wasn't actually able to test this b/c remote desktop doesn't support touch. But should work. If Plaban could test that would be great.