### PR TITLE
fix: remove canvas transition

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -55,6 +55,11 @@ const styles = `
     -ms-user-select: none;
   }
 
+  .blocklyBlockCanvas.blocklyCanvasTransitioning,
+  .blocklyBubbleCanvas.blocklyCanvasTransitioning {
+    transition: none;
+  }
+
   .blocklyWidgetDiv.fieldTextInput {
     overflow: hidden;
     border: 1px solid;
@@ -81,13 +86,6 @@ const styles = `
     left: 50%;
     margin-left: -12px;
     cursor: pointer;
-  }
-
-  .blocklyNonSelectable {
-    user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
   }
 
   .blocklyWsDragSurface {


### PR DESCRIPTION
### Resolves

Fixes https://github.com/gonfunko/scratch-blocks/issues/66

### Proposed Changes

Makes it so the transition happens instantly by overwriting [the CSS that gives it a transition](https://github.com/google/blockly/blob/032b5ed9eaa87f610beb34f977992aa1c0c8ff0c/core/css.ts#L91).

### Test Coverage

Manually tested

### Additional info.

Also the `blocklyNonSelectable` css was duplicated so I deleted one of them. The remaining one is directly above the code I added, so you can expand the diff upward to check.