### PR TITLE
fix: reenable support for dragging blocks between sprites

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -45,7 +45,11 @@ const styles = `
     height: 100%;
     position: relative;
     overflow: hidden; /* So blocks in drag surface disappear at edges */
-    touch-action: none
+    touch-action: none;
+  }
+
+  .injectionDiv.boundless {
+    overflow: visible;
   }
 
   .blocklyNonSelectable {

--- a/src/events_block_drag_end.js
+++ b/src/events_block_drag_end.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+export class BlockDragEnd extends Blockly.Events.BlockBase {
+  constructor(block, isOutside) {
+    super(block);
+    this.type = "endDrag";
+    this.isOutside = isOutside;
+    this.recordUndo = false;
+    this.xml = Blockly.Xml.blockToDom(block, true);
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      isOutside: this.isOutside,
+      xml: this.xml,
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.isOutside = json["isOutside"];
+    newEvent.xml = json["xml"];
+
+    return newEvent;
+  }
+}

--- a/src/events_block_drag_outside.js
+++ b/src/events_block_drag_outside.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+export class BlockDragOutside extends Blockly.Events.BlockBase {
+  constructor(block, isOutside) {
+    super(block);
+    this.type = "dragOutside";
+    this.isOutside = isOutside;
+    this.recordUndo = false;
+  }
+
+  toJson() {
+    return {
+      ...super.toJson(),
+      isOutside: this.isOutside,
+    };
+  }
+
+  static fromJson(json, workspace, event) {
+    const newEvent = super.fromJson(json, workspace, event);
+    newEvent.isOutside = json["isOutside"];
+
+    return newEvent;
+  }
+}

--- a/src/scratch_dragger.js
+++ b/src/scratch_dragger.js
@@ -5,10 +5,59 @@
  */
 
 import * as Blockly from "blockly/core";
+import { BlockDragOutside } from "./events_block_drag_outside.js";
+import { BlockDragEnd } from "./events_block_drag_end.js";
+
+const BOUNDLESS_CLASS = "boundless";
 
 class ScratchDragger extends Blockly.dragging.Dragger {
+  constructor(draggable, workspace) {
+    super(draggable, workspace);
+    this.draggedOutOfBounds = false;
+    this.originatedFromFlyout = false;
+  }
+
   setDraggable(draggable) {
     this.draggable = draggable;
+  }
+
+  onDragStart(event) {
+    super.onDragStart(event);
+    if (this.draggable instanceof Blockly.BlockSvg) {
+      this.workspace.addClass(BOUNDLESS_CLASS);
+      const absoluteMetrics = this.workspace
+        .getMetricsManager()
+        .getAbsoluteMetrics();
+      const viewMetrics = this.workspace.getMetricsManager().getViewMetrics();
+      if (
+        this.workspace.RTL
+          ? event.clientX >
+            this.workspace.getParentSvg().getBoundingClientRect().left +
+              viewMetrics.width
+          : event.clientX < absoluteMetrics.left
+      ) {
+        this.originatedFromFlyout = true;
+      }
+    }
+  }
+
+  onDrag(event, totalDelta) {
+    super.onDrag(event, totalDelta);
+    this.updateOutOfBoundsState(event);
+  }
+
+  updateOutOfBoundsState(event) {
+    if (this.draggable instanceof Blockly.BlockSvg) {
+      const outOfBounds = !this.isInsideWorkspace(event);
+      if (outOfBounds !== this.draggedOutOfBounds) {
+        const event = new BlockDragOutside(
+          this.getDragRoot(this.draggable),
+          outOfBounds
+        );
+        Blockly.Events.fire(event);
+        this.draggedOutOfBounds = outOfBounds;
+      }
+    }
   }
 
   onDragEnd(event) {
@@ -29,7 +78,58 @@ class ScratchDragger extends Blockly.dragging.Dragger {
         return;
       }
     }
+
     super.onDragEnd(event);
+
+    this.updateOutOfBoundsState(event);
+    if (this.draggable instanceof Blockly.BlockSvg) {
+      const event = new BlockDragEnd(
+        this.getDragRoot(this.draggable),
+        this.draggedOutOfBounds
+      );
+      Blockly.Events.fire(event);
+      // If this block was dragged out of the flyout and dropped outside of
+      // the workspace (e.g. on a different sprite), the block that was created
+      // on the workspace in order to depict the block mid-drag needs to be
+      // deleted.
+      if (this.originatedFromFlyout && this.draggedOutOfBounds) {
+        Blockly.renderManagement.finishQueuedRenders().then(() => {
+          this.getDragRoot(this.draggable).dispose();
+        });
+      }
+    }
+    this.workspace.removeClass(BOUNDLESS_CLASS);
+  }
+
+  shouldReturnToStart(event, rootDraggable) {
+    // If a block is dragged out of the workspace to be e.g. dropped on another
+    // sprite, it should remain in the same place on the workspace where it was,
+    // rather than being moved to an invisible part of the workspace.
+    return (
+      this.draggedOutOfBounds || super.shouldReturnToStart(event, rootDraggable)
+    );
+  }
+
+  getDragRoot(block) {
+    // We can't just use getRootBlock() here because, when blocks are detached
+    // from a stack via dragging, getRootBlock() still returns the root of that
+    // stack.
+    if (block.isShadow()) {
+      return block.getParent();
+    }
+
+    return block;
+  }
+
+  isInsideWorkspace(event) {
+    const bounds = this.workspace.getParentSvg().getBoundingClientRect();
+    const workspaceRect = new Blockly.utils.Rect(
+      bounds.top,
+      bounds.bottom,
+      bounds.left,
+      bounds.right
+    );
+    return workspaceRect.contains(event.clientX, event.clientY);
   }
 }
 


### PR DESCRIPTION
This PR fixes #11 and #12. It adds drag end and drag outside events that the Scratch VM listens for in order to handle copying blocks between sprites when dragging a block/stack onto a different sprite or the stage. It also updates the custom dragger to fire these events in the manner the VM expects and otherwise manipulate things during drags outside of the workspace bounds.