### PR TITLE
fix: don't warn about procedure references when moving the definition on the workspace

### DIFF
--- a/src/scratch_dragger.js
+++ b/src/scratch_dragger.js
@@ -14,7 +14,8 @@ class ScratchDragger extends Blockly.dragging.Dragger {
   onDragEnd(event) {
     if (
       this.draggable instanceof Blockly.BlockSvg &&
-      this.draggable.type === "procedures_definition"
+      this.draggable.type === "procedures_definition" &&
+      this.wouldDeleteDraggable(event, this.draggable.getRootBlock())
     ) {
       const procCode = this.draggable
         .getInputTargetBlock("custom_block")


### PR DESCRIPTION
This PR fixes a bug where dragging a procedure definition around anywhere on the workspace would prompt you to delete references to it before deleting it. Now, this alert will only be shown when the drag would drop the procedure definition block on a delete area.