### PR TITLE
fix: don't show scope options when renaming a variable from the variable getter context menu

### DIFF
--- a/src/blocks/data.js
+++ b/src/blocks/data.js
@@ -22,6 +22,7 @@ import * as Blockly from "blockly/core";
 import { Categories } from "../categories.js";
 import * as Constants from "../constants.js";
 import * as scratchBlocksUtils from "../scratch_blocks_utils.js";
+import { renameVariable } from "../variables.js";
 
 Blockly.Blocks["data_variable"] = {
   /**
@@ -670,7 +671,7 @@ const RENAME_OPTION_CALLBACK_FACTORY = function (block, fieldName) {
   return function () {
     var workspace = block.workspace;
     var variable = block.getField(fieldName).getVariable();
-    Blockly.Variables.renameVariable(workspace, variable);
+    renameVariable(workspace, variable);
   };
 };
 


### PR DESCRIPTION
This PR fixes #137. Suppressing the scope options when renaming a variable was fixed for the context menu item in the variable picker dropdown item, but this fixes it for the contextual menu on the variable getter block.