### PR TITLE
fix: select new variable blocks' monitor checkboxes after creation

### DIFF
--- a/src/scratch_continuous_toolbox.js
+++ b/src/scratch_continuous_toolbox.js
@@ -2,11 +2,21 @@ import * as Blockly from "blockly/core";
 import { ContinuousToolbox } from "@blockly/continuous-toolbox";
 
 export class ScratchContinuousToolbox extends ContinuousToolbox {
+  postRenderCallbacks = [];
+
   refreshSelection() {
     // Intentionally a no-op, Scratch manually manages refreshing the toolbox via forceRerender().
   }
 
   forceRerender() {
     super.refreshSelection();
+    let callback;
+    while ((callback = this.postRenderCallbacks.shift())) {
+      callback();
+    }
+  }
+
+  runAfterRerender(callback) {
+    this.postRenderCallbacks.push(callback);
   }
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -117,9 +117,9 @@ export function createVariable(workspace, opt_callback, opt_type) {
 
         var flyout = workspace.isFlyout ? workspace : workspace.getFlyout();
         var variableBlockId = variable.getId();
-        if (flyout.setCheckboxState) {
+        workspace.getToolbox().runAfterRerender(() => {
           flyout.setCheckboxState(variableBlockId, true);
-        }
+        });
 
         if (opt_callback) {
           opt_callback(variableBlockId);


### PR DESCRIPTION
In Scratch, newly created variables have their monitor checkbox automatically checked so that their value will be displayed on the stage. This PR fixes things up to preserve that behavior. This fixes #135.