### PR TITLE
fix: fix toolbox category selection

### DIFF
--- a/src/scratch_continuous_toolbox.js
+++ b/src/scratch_continuous_toolbox.js
@@ -9,11 +9,13 @@ export class ScratchContinuousToolbox extends ContinuousToolbox {
   }
 
   forceRerender() {
+    const selectedCategoryName = this.selectedItem_?.getName();
     super.refreshSelection();
     let callback;
     while ((callback = this.postRenderCallbacks.shift())) {
       callback();
     }
+    this.selectCategoryByName(selectedCategoryName);
   }
 
   runAfterRerender(callback) {


### PR DESCRIPTION
This PR fixes several issues:

* The Motion toolbox category wasn't displayed as selected by default when loading the page
* Switching between sprites/the stage would occasionally deselect the selected category