### PR TITLE
fix: fix dropdown menu metrics

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -1348,6 +1348,8 @@ const styles = `
   .blocklyDropDownDiv .blocklyMenuItem {
     color: #fff;
     font-weight: bold;
+    min-height: 32px;
+    padding: 4px 7em 4px 28px;
   }
   .blocklyToolboxSelected .blocklyTreeLabel {
     color: var(--colour-toolboxText);


### PR DESCRIPTION
This PR fixes dropdown menu metrics to align with Scratch by adding larger touch targets for dropdown menu items. This fixes #109.