### PR TITLE
fix: fix styling of dropdown menus

### DIFF
--- a/src/blocks/control.js
+++ b/src/blocks/control.js
@@ -20,7 +20,6 @@
 
 import * as Blockly from "blockly/core";
 import { Categories } from "../categories.js";
-import { Colours } from "../colours.js";
 
 Blockly.Blocks["control_forever"] = {
   /**
@@ -198,12 +197,7 @@ Blockly.Blocks["control_stop"] = {
     this.appendDummyInput()
       .appendField(Blockly.Msg.CONTROL_STOP)
       .appendField(stopDropdown, "STOP_OPTION");
-    this.setColour(
-      Colours.control.primary,
-      Colours.control.secondary,
-      Colours.control.tertiary,
-      Colours.control.quaternary
-    );
+    this.setStyle("colours_control");
     this.setPreviousStatement(true);
   },
 };

--- a/src/blocks/control.js
+++ b/src/blocks/control.js
@@ -375,12 +375,10 @@ Blockly.Blocks["control_start_as_clone"] = {
   },
 };
 
-Blockly.Blocks["control_create_clone_of_menu"] = {
-  /**
-   * Create-clone drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Create-clone drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["control_create_clone_of_menu"] = {};
 
 Blockly.Blocks["control_create_clone_of"] = {
   /**

--- a/src/blocks/control.js
+++ b/src/blocks/control.js
@@ -383,22 +383,9 @@ Blockly.Blocks["control_start_as_clone"] = {
 
 Blockly.Blocks["control_create_clone_of_menu"] = {
   /**
-   * Create-clone drop-down menu.
+   * Create-clone drop-down menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "CLONE_OPTION",
-          options: [[Blockly.Msg.CONTROL_CREATECLONEOF_MYSELF, "_myself_"]],
-        },
-      ],
-      extensions: ["colours_control", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["control_create_clone_of"] = {

--- a/src/blocks/event.js
+++ b/src/blocks/event.js
@@ -145,22 +145,9 @@ Blockly.Blocks["event_whenbroadcastreceived"] = {
 Blockly.Blocks["event_whenbackdropswitchesto"] = {
   /**
    * Block for when the current backdrop switched to a selected backdrop.
+   * Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: Blockly.Msg.EVENT_WHENBACKDROPSWITCHESTO,
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "BACKDROP",
-          options: [["backdrop1", "BACKDROP1"]],
-        },
-      ],
-      category: Categories.event,
-      extensions: ["colours_event", "shape_hat"],
-    });
-  },
 };
 
 Blockly.Blocks["event_whengreaterthan"] = {

--- a/src/blocks/event.js
+++ b/src/blocks/event.js
@@ -142,13 +142,11 @@ Blockly.Blocks["event_whenbroadcastreceived"] = {
   },
 };
 
-Blockly.Blocks["event_whenbackdropswitchesto"] = {
-  /**
-   * Block for when the current backdrop switched to a selected backdrop.
-   * Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Block for when the current backdrop switched to a selected backdrop.
+ * Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["event_whenbackdropswitchesto"] = {};
 
 Blockly.Blocks["event_whengreaterthan"] = {
   /**

--- a/src/blocks/looks.js
+++ b/src/blocks/looks.js
@@ -339,12 +339,10 @@ Blockly.Blocks["looks_setstretchto"] = {
   },
 };
 
-Blockly.Blocks["looks_costume"] = {
-  /**
-   * Costumes drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Costumes drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["looks_costume"] = {};
 
 Blockly.Blocks["looks_switchcostumeto"] = {
   /**
@@ -400,12 +398,10 @@ Blockly.Blocks["looks_switchbackdropto"] = {
   },
 };
 
-Blockly.Blocks["looks_backdrops"] = {
-  /**
-   * Backdrop list. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Backdrop list. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["looks_backdrops"] = {};
 
 Blockly.Blocks["looks_gotofrontback"] = {
   /**

--- a/src/blocks/looks.js
+++ b/src/blocks/looks.js
@@ -341,25 +341,9 @@ Blockly.Blocks["looks_setstretchto"] = {
 
 Blockly.Blocks["looks_costume"] = {
   /**
-   * Costumes drop-down menu.
+   * Costumes drop-down menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "COSTUME",
-          options: [
-            ["costume1", "COSTUME1"],
-            ["costume2", "COSTUME2"],
-          ],
-        },
-      ],
-      extensions: ["colours_looks", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["looks_switchcostumeto"] = {
@@ -418,23 +402,9 @@ Blockly.Blocks["looks_switchbackdropto"] = {
 
 Blockly.Blocks["looks_backdrops"] = {
   /**
-   * Backdrop list
+   * Backdrop list. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      id: "looks_backdrops",
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "BACKDROP",
-          options: [["backdrop1", "BACKDROP1"]],
-        },
-      ],
-      extensions: ["colours_looks", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["looks_gotofrontback"] = {

--- a/src/blocks/math.js
+++ b/src/blocks/math.js
@@ -23,7 +23,6 @@
  * @author q.neutron@gmail.com (Quynh Neutron)
  */
 import * as Blockly from "blockly/core";
-import { Colours } from "../colours.js";
 import * as Constants from "../constants.js";
 
 Blockly.Blocks["math_number"] = {
@@ -43,10 +42,7 @@ Blockly.Blocks["math_number"] = {
       ],
       output: "Number",
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };
@@ -68,10 +64,7 @@ Blockly.Blocks["math_integer"] = {
       ],
       output: "Number",
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };
@@ -94,10 +87,7 @@ Blockly.Blocks["math_whole_number"] = {
       ],
       output: "Number",
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };
@@ -119,10 +109,7 @@ Blockly.Blocks["math_positive_number"] = {
       ],
       output: "Number",
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };
@@ -144,10 +131,7 @@ Blockly.Blocks["math_angle"] = {
       ],
       output: "Number",
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };

--- a/src/blocks/motion.js
+++ b/src/blocks/motion.js
@@ -115,12 +115,10 @@ Blockly.Blocks["motion_pointindirection"] = {
   },
 };
 
-Blockly.Blocks["motion_pointtowards_menu"] = {
-  /**
-   * Point towards drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Point towards drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["motion_pointtowards_menu"] = {};
 
 Blockly.Blocks["motion_pointtowards"] = {
   /**
@@ -142,12 +140,10 @@ Blockly.Blocks["motion_pointtowards"] = {
   },
 };
 
-Blockly.Blocks["motion_goto_menu"] = {
-  /**
-   * Go to drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Go to drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["motion_goto_menu"] = {};
 
 Blockly.Blocks["motion_gotoxy"] = {
   /**
@@ -221,12 +217,10 @@ Blockly.Blocks["motion_glidesecstoxy"] = {
   },
 };
 
-Blockly.Blocks["motion_glideto_menu"] = {
-  /**
-   * Glide to drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Glide to drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["motion_glideto_menu"] = {};
 
 Blockly.Blocks["motion_glideto"] = {
   /**

--- a/src/blocks/motion.js
+++ b/src/blocks/motion.js
@@ -117,25 +117,9 @@ Blockly.Blocks["motion_pointindirection"] = {
 
 Blockly.Blocks["motion_pointtowards_menu"] = {
   /**
-   * Point towards drop-down menu.
+   * Point towards drop-down menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "TOWARDS",
-          options: [
-            [Blockly.Msg.MOTION_POINTTOWARDS_POINTER, "_mouse_"],
-            [Blockly.Msg.MOTION_POINTTOWARDS_RANDOM, "_random_"],
-          ],
-        },
-      ],
-      extensions: ["colours_motion", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["motion_pointtowards"] = {
@@ -160,25 +144,9 @@ Blockly.Blocks["motion_pointtowards"] = {
 
 Blockly.Blocks["motion_goto_menu"] = {
   /**
-   * Go to drop-down menu.
+   * Go to drop-down menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "TO",
-          options: [
-            [Blockly.Msg.MOTION_GOTO_POINTER, "_mouse_"],
-            [Blockly.Msg.MOTION_GOTO_RANDOM, "_random_"],
-          ],
-        },
-      ],
-      extensions: ["colours_motion", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["motion_gotoxy"] = {
@@ -255,25 +223,9 @@ Blockly.Blocks["motion_glidesecstoxy"] = {
 
 Blockly.Blocks["motion_glideto_menu"] = {
   /**
-   * Glide to drop-down menu
+   * Glide to drop-down menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "TO",
-          options: [
-            [Blockly.Msg.MOTION_GLIDETO_POINTER, "_mouse_"],
-            [Blockly.Msg.MOTION_GLIDETO_RANDOM, "_random_"],
-          ],
-        },
-      ],
-      extensions: ["colours_motion", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["motion_glideto"] = {

--- a/src/blocks/note.js
+++ b/src/blocks/note.js
@@ -23,7 +23,6 @@
  * @author ericr@media.mit.edu (Eric Rosenbaum)
  */
 import * as Blockly from "blockly/core";
-import { Colours } from "../colours.js";
 import * as Constants from "../constants.js";
 
 Blockly.Blocks["note"] = {
@@ -43,10 +42,7 @@ Blockly.Blocks["note"] = {
       ],
       outputShape: Constants.OUTPUT_SHAPE_ROUND,
       output: "Number",
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };

--- a/src/blocks/procedures.js
+++ b/src/blocks/procedures.js
@@ -23,7 +23,6 @@
  */
 
 import * as Blockly from "blockly/core";
-import { Colours } from "../colours.js";
 import { FieldTextInputRemovable } from "../fields/field_textinput_removable.js";
 
 class DuplicateOnDragDraggable {
@@ -984,11 +983,7 @@ Blockly.Blocks["argument_editor_boolean"] = {
           text: "foo",
         },
       ],
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
-      extensions: ["output_boolean"],
+      extensions: ["colours_textfield", "output_boolean"],
     });
 
     // Exist on declaration and arguments editors, with different implementations.
@@ -1007,11 +1002,7 @@ Blockly.Blocks["argument_editor_string_number"] = {
           text: "foo",
         },
       ],
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
-      extensions: ["output_number", "output_string"],
+      extensions: ["colours_textfield", "output_number", "output_string"],
     });
 
     // Exist on declaration and arguments editors, with different implementations.

--- a/src/blocks/sensing.js
+++ b/src/blocks/sensing.js
@@ -44,25 +44,9 @@ Blockly.Blocks["sensing_touchingobject"] = {
 
 Blockly.Blocks["sensing_touchingobjectmenu"] = {
   /**
-   * "Touching [Object]" Block Menu.
+   * "Touching [Object]" Block Menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "TOUCHINGOBJECTMENU",
-          options: [
-            [Blockly.Msg.SENSING_TOUCHINGOBJECT_POINTER, "_mouse_"],
-            [Blockly.Msg.SENSING_TOUCHINGOBJECT_EDGE, "_edge_"],
-          ],
-        },
-      ],
-      extensions: ["colours_sensing", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["sensing_touchingcolor"] = {
@@ -131,22 +115,9 @@ Blockly.Blocks["sensing_distanceto"] = {
 
 Blockly.Blocks["sensing_distancetomenu"] = {
   /**
-   * "Distance to [Object]" Block Menu.
+   * "Distance to [Object]" Block Menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "DISTANCETOMENU",
-          options: [[Blockly.Msg.SENSING_DISTANCETO_POINTER, "_mouse_"]],
-        },
-      ],
-      extensions: ["colours_sensing", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["sensing_askandwait"] = {
@@ -395,63 +366,17 @@ Blockly.Blocks["sensing_resettimer"] = {
 
 Blockly.Blocks["sensing_of_object_menu"] = {
   /**
-   * "* of _" object menu.
+   * "* of _" object menu. Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: "%1",
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "OBJECT",
-          options: [
-            ["Sprite1", "Sprite1"],
-            ["Stage", "_stage_"],
-          ],
-        },
-      ],
-      category: Categories.sensing,
-      extensions: ["colours_sensing", "output_string"],
-    });
-  },
 };
 
 Blockly.Blocks["sensing_of"] = {
   /**
    * Block to report properties of sprites.
+   * Populated dynamically by scratch-gui.
    * @this Blockly.Block
    */
-  init: function () {
-    this.jsonInit({
-      message0: Blockly.Msg.SENSING_OF,
-      args0: [
-        {
-          type: "field_dropdown",
-          name: "PROPERTY",
-          options: [
-            [Blockly.Msg.SENSING_OF_XPOSITION, "x position"],
-            [Blockly.Msg.SENSING_OF_YPOSITION, "y position"],
-            [Blockly.Msg.SENSING_OF_DIRECTION, "direction"],
-            [Blockly.Msg.SENSING_OF_COSTUMENUMBER, "costume #"],
-            [Blockly.Msg.SENSING_OF_COSTUMENAME, "costume name"],
-            [Blockly.Msg.SENSING_OF_SIZE, "size"],
-            [Blockly.Msg.SENSING_OF_VOLUME, "volume"],
-            [Blockly.Msg.SENSING_OF_BACKDROPNUMBER, "backdrop #"],
-            [Blockly.Msg.SENSING_OF_BACKDROPNAME, "backdrop name"],
-          ],
-        },
-        {
-          type: "input_value",
-          name: "OBJECT",
-        },
-      ],
-      output: true,
-      category: Categories.sensing,
-      outputShape: Constants.OUTPUT_SHAPE_ROUND,
-      extensions: ["colours_sensing"],
-    });
-  },
 };
 
 Blockly.Blocks["sensing_current"] = {

--- a/src/blocks/sensing.js
+++ b/src/blocks/sensing.js
@@ -42,12 +42,10 @@ Blockly.Blocks["sensing_touchingobject"] = {
   },
 };
 
-Blockly.Blocks["sensing_touchingobjectmenu"] = {
-  /**
-   * "Touching [Object]" Block Menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * "Touching [Object]" Block Menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["sensing_touchingobjectmenu"] = {};
 
 Blockly.Blocks["sensing_touchingcolor"] = {
   /**
@@ -113,12 +111,10 @@ Blockly.Blocks["sensing_distanceto"] = {
   },
 };
 
-Blockly.Blocks["sensing_distancetomenu"] = {
-  /**
-   * "Distance to [Object]" Block Menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * "Distance to [Object]" Block Menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["sensing_distancetomenu"] = {};
 
 Blockly.Blocks["sensing_askandwait"] = {
   /**
@@ -364,20 +360,15 @@ Blockly.Blocks["sensing_resettimer"] = {
   },
 };
 
-Blockly.Blocks["sensing_of_object_menu"] = {
-  /**
-   * "* of _" object menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * "* of _" object menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["sensing_of_object_menu"] = {};
 
-Blockly.Blocks["sensing_of"] = {
-  /**
-   * Block to report properties of sprites.
-   * Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Block to report properties of sprites. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["sensing_of"] = {};
 
 Blockly.Blocks["sensing_current"] = {
   /**

--- a/src/blocks/sound.js
+++ b/src/blocks/sound.js
@@ -21,12 +21,10 @@
 import * as Blockly from "blockly/core";
 import { Categories } from "../categories.js";
 
-Blockly.Blocks["sound_sounds_menu"] = {
-  /**
-   * Sound effects drop-down menu. Populated dynamically by scratch-gui.
-   * @this Blockly.Block
-   */
-};
+/**
+ * Sound effects drop-down menu. Populated dynamically by scratch-gui.
+ */
+Blockly.Blocks["sound_sounds_menu"] = {};
 
 Blockly.Blocks["sound_play"] = {
   /**

--- a/src/blocks/text.js
+++ b/src/blocks/text.js
@@ -23,7 +23,6 @@
  * @author fraser@google.com (Neil Fraser)
  */
 import * as Blockly from "blockly/core";
-import { Colours } from "../colours.js";
 
 Blockly.Blocks["text"] = {
   /**
@@ -40,10 +39,7 @@ Blockly.Blocks["text"] = {
         },
       ],
       output: "String",
-      colour: Colours.textField,
-      colourSecondary: Colours.textField,
-      colourTertiary: Colours.textField,
-      colourQuaternary: Colours.textField,
+      extensions: ["colours_textfield"],
     });
   },
 };

--- a/src/blocks/vertical_extensions.js
+++ b/src/blocks/vertical_extensions.js
@@ -53,14 +53,11 @@ VerticalExtensions.colourHelper = function (category) {
     throw new Error('Could not find colours for category "' + category + '"');
   }
   /**
-   * Set the primary, secondary, tertiary, and quaternary colours on this block for
-   * the given category.
+   * Set the block style on this block for the given category.
    * @this {Blockly.Block}
    */
   return function () {
-    this.setColour(colours.primary);
-    // this.setColourFromRawValues_(colours.primary, colours.secondary,
-    //     colours.tertiary, colours.quaternary);
+    this.setStyle(`colours_${category}`);
   };
 };
 

--- a/src/blocks/vertical_extensions.js
+++ b/src/blocks/vertical_extensions.js
@@ -26,32 +26,18 @@
  * @author fenichel@google.com (Rachel Fenichel)
  */
 import * as Blockly from "blockly/core";
-import { Colours } from "../colours.js";
 import { ScratchProcedures } from "../procedures.js";
 import * as Constants from "../constants.js";
 
 const VerticalExtensions = {};
 /**
  * Helper function that generates an extension based on a category name.
- * The generated function will set primary, secondary, tertiary, and quaternary
- * colours based on the category name.
+ * The generated function will set the block's style based on the category name.
  * @param {String} category The name of the category to set colours for.
  * @return {function} An extension function that sets colours based on the given
  *     category.
  */
 VerticalExtensions.colourHelper = function (category) {
-  var colours = Colours[category];
-  if (
-    !(
-      colours &&
-      colours.primary &&
-      colours.secondary &&
-      colours.tertiary &&
-      colours.quaternary
-    )
-  ) {
-    throw new Error('Could not find colours for category "' + category + '"');
-  }
   /**
    * Set the block style on this block for the given category.
    * @this {Blockly.Block}
@@ -65,10 +51,7 @@ VerticalExtensions.colourHelper = function (category) {
  * Extension to set the colours of a text field, which are all the same.
  */
 VerticalExtensions.COLOUR_TEXTFIELD = function () {
-  this.setColour(colours.textField);
-  // this.setColourFromRawValues_(Colours.textField,
-  //     Colours.textField, Colours.textField,
-  //     Colours.textField);
+  VerticalExtensions.colourHelper("textField").apply(this);
 };
 
 /**

--- a/src/colours.js
+++ b/src/colours.js
@@ -20,7 +20,7 @@
 import * as Blockly from "blockly/core";
 
 const cssColours = {
-  // SVG colours: these must be specificed in #RRGGBB style
+  // SVG colours: these must be specified in #RRGGBB style
   // To add an opacity, this must be specified as a separate property (for SVG fill-opacity)
   motion: {
     primary: "#4C97FF",
@@ -154,6 +154,22 @@ const Colours = {
         }
       }
     }
+  },
+  registerBlockStyles: function () {
+    const workspace = Blockly.getMainWorkspace();
+    const theme = workspace.getTheme();
+    for (const key of Object.keys(cssColours)) {
+      if (cssColours[key].hasOwnProperty("primary")) {
+        const colours = cssColours[key];
+        theme.setBlockStyle(`colours_${key}`, {
+          colourPrimary: colours.primary,
+          colourSecondary: colours.secondary,
+          colourTertiary: colours.tertiary,
+          colourQuaternary: colours.quaternary,
+        });
+      }
+    }
+    workspace.setTheme(theme);
   },
 };
 

--- a/src/colours.js
+++ b/src/colours.js
@@ -40,6 +40,12 @@ const cssColours = {
     tertiary: "#BD42BD",
     quaternary: "#BD42BD",
   },
+  sound: {
+    primary: "#CF63CF",
+    secondary: "#C94FC9",
+    tertiary: "#BD42BD",
+    quaternary: "#BD42BD",
+  },
   control: {
     primary: "#FFAB19",
     secondary: "#EC9C13",

--- a/src/colours.js
+++ b/src/colours.js
@@ -40,12 +40,6 @@ const cssColours = {
     tertiary: "#BD42BD",
     quaternary: "#BD42BD",
   },
-  sound: {
-    primary: "#CF63CF",
-    secondary: "#C94FC9",
-    tertiary: "#BD42BD",
-    quaternary: "#BD42BD",
-  },
   control: {
     primary: "#FFAB19",
     secondary: "#EC9C13",

--- a/src/colours.js
+++ b/src/colours.js
@@ -19,77 +19,9 @@
  */
 import * as Blockly from "blockly/core";
 
-const cssColours = {
+const Colours = {
   // SVG colours: these must be specified in #RRGGBB style
   // To add an opacity, this must be specified as a separate property (for SVG fill-opacity)
-  motion: {
-    primary: "#4C97FF",
-    secondary: "#4280D7",
-    tertiary: "#3373CC",
-    quaternary: "#3373CC",
-  },
-  looks: {
-    primary: "#9966FF",
-    secondary: "#855CD6",
-    tertiary: "#774DCB",
-    quaternary: "#774DCB",
-  },
-  sounds: {
-    primary: "#CF63CF",
-    secondary: "#C94FC9",
-    tertiary: "#BD42BD",
-    quaternary: "#BD42BD",
-  },
-  control: {
-    primary: "#FFAB19",
-    secondary: "#EC9C13",
-    tertiary: "#CF8B17",
-    quaternary: "#CF8B17",
-  },
-  event: {
-    primary: "#FFBF00",
-    secondary: "#E6AC00",
-    tertiary: "#CC9900",
-    quaternary: "#CC9900",
-  },
-  sensing: {
-    primary: "#5CB1D6",
-    secondary: "#47A8D1",
-    tertiary: "#2E8EB8",
-    quaternary: "#2E8EB8",
-  },
-  pen: {
-    primary: "#0fBD8C",
-    secondary: "#0DA57A",
-    tertiary: "#0B8E69",
-    quaternary: "#0B8E69",
-  },
-  operators: {
-    primary: "#59C059",
-    secondary: "#46B946",
-    tertiary: "#389438",
-    quaternary: "#389438",
-  },
-  data: {
-    primary: "#FF8C1A",
-    secondary: "#FF8000",
-    tertiary: "#DB6E00",
-    quaternary: "#DB6E00",
-  },
-  // This is not a new category, but rather for differentiation
-  // between lists and scalar variables.
-  data_lists: {
-    primary: "#FF661A",
-    secondary: "#FF5500",
-    tertiary: "#E64D00",
-    quaternary: "#E64D00",
-  },
-  more: {
-    primary: "#FF6680",
-    secondary: "#FF4D6A",
-    tertiary: "#FF3355",
-    quaternary: "#FF3355",
-  },
   text: "#FFFFFF",
   workspace: "#F9F9F9",
   toolboxHover: "#4C97FF",
@@ -123,56 +55,6 @@ const cssColours = {
   menuHover: "rgba(77, 151, 255, .25)",
 };
 
-const Colours = {
-  ...cssColours,
-  overrideColours: function (colours) {
-    // Colour overrides provided by the injection
-    if (colours) {
-      for (var colourProperty in colours) {
-        if (
-          colours.hasOwnProperty(colourProperty) &&
-          this.hasOwnProperty(colourProperty)
-        ) {
-          // If a property is in both colours option and Blockly.Colours,
-          // set the Blockly.Colours value to the override.
-          // Override Blockly category color object properties with those
-          // provided.
-          var colourPropertyValue = colours[colourProperty];
-          if (goog.isObject(colourPropertyValue)) {
-            for (var colourSequence in colourPropertyValue) {
-              if (
-                colourPropertyValue.hasOwnProperty(colourSequence) &&
-                this[colourProperty].hasOwnProperty(colourSequence)
-              ) {
-                this[colourProperty][colourSequence] =
-                  colourPropertyValue[colourSequence];
-              }
-            }
-          } else {
-            this[colourProperty] = colourPropertyValue;
-          }
-        }
-      }
-    }
-  },
-  registerBlockStyles: function () {
-    const workspace = Blockly.getMainWorkspace();
-    const theme = workspace.getTheme();
-    for (const key of Object.keys(cssColours)) {
-      if (cssColours[key].hasOwnProperty("primary")) {
-        const colours = cssColours[key];
-        theme.setBlockStyle(`colours_${key}`, {
-          colourPrimary: colours.primary,
-          colourSecondary: colours.secondary,
-          colourTertiary: colours.tertiary,
-          colourQuaternary: colours.quaternary,
-        });
-      }
-    }
-    workspace.setTheme(theme);
-  },
-};
-
 function varify(coloursObj, prefix = "--colour") {
   return Object.keys(coloursObj)
     .map((key) => {
@@ -187,7 +69,7 @@ function varify(coloursObj, prefix = "--colour") {
 }
 
 const cssVariables = `:root {
-  ${varify(cssColours)}
+  ${varify(Colours)}
 }`;
 
 Blockly.Css.register(cssVariables);

--- a/src/css.js
+++ b/src/css.js
@@ -413,19 +413,19 @@ const styles = `
     cursor: pointer;
   }
 
-  .scratch-renderer.zelos-theme .blocklyFlyoutLabelText {
+  .scratch-renderer.scratch-theme .blocklyFlyoutLabelText {
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     font-size: 14pt;
     fill: #575E75;
     font-weight: bold;
   }
 
-  .scratch-renderer.zelos-theme .blocklyText,
-  .scratch-renderer.zelos-theme .blocklyHtmlInput {
+  .scratch-renderer.scratch-theme .blocklyText,
+  .scratch-renderer.scratch-theme .blocklyHtmlInput {
     font-weight: 500;
   }
 
-  .scratch-renderer.zelos-theme .blocklyFlyoutButton .blocklyText {
+  .scratch-renderer.scratch-theme .blocklyFlyoutButton .blocklyText {
     fill: var(--colour-textFieldText);
   }
 
@@ -1116,7 +1116,7 @@ const styles = `
     transform: rotate(-180deg);
   }
 
-  .scratch-renderer.zelos-theme .blocklyComment .blocklyTextarea {
+  .scratch-renderer.scratch-theme .blocklyComment .blocklyTextarea {
     border: none;
     --commentFillColour: #fef49c;
     font-size: 12pt;
@@ -1125,7 +1125,7 @@ const styles = `
     color: #575e75;
   }
 
-  .scratch-renderer.zelos-theme .blocklyCommentText.blocklyText {
+  .scratch-renderer.scratch-theme .blocklyCommentText.blocklyText {
     font-weight: 400;
   }
 
@@ -1160,8 +1160,8 @@ const styles = `
     width: 20px;
   }
 
-  .scratch-renderer.zelos-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>rect,
-  .scratch-renderer.zelos-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>.blocklyPath {
+  .scratch-renderer.scratch-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>rect,
+  .scratch-renderer.scratch-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>.blocklyPath {
     stroke: revert-layer;
     stroke-width: 1;
   }

--- a/src/css.js
+++ b/src/css.js
@@ -1159,6 +1159,12 @@ const styles = `
     height: 20px;
     width: 20px;
   }
+
+  .scratch-renderer.zelos-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>rect,
+  .scratch-renderer.zelos-theme .blocklyDraggable:not(.blocklyDisabled) .blocklyEditableField:not(.blocklyEditing):hover>.blocklyPath {
+    stroke: revert-layer;
+    stroke-width: 1;
+  }
 `;
 
 Blockly.Css.register(styles);

--- a/src/fields/field_dropdown.js
+++ b/src/fields/field_dropdown.js
@@ -11,7 +11,10 @@ class FieldDropdown extends Blockly.FieldDropdown {
     super.showEditor_(event);
     const sourceBlock = this.getSourceBlock();
     if (sourceBlock.isShadow()) {
-      sourceBlock.setColour(sourceBlock.style.colourQuaternary);
+      this.originalStyle = sourceBlock.getStyleName();
+      sourceBlock.setColour(
+        sourceBlock.style.colourQuaternary ?? sourceBlock.style.colourTertiary
+      );
     }
   }
 
@@ -19,7 +22,7 @@ class FieldDropdown extends Blockly.FieldDropdown {
     super.dropdownDispose_();
     const sourceBlock = this.getSourceBlock();
     if (sourceBlock.isShadow()) {
-      sourceBlock.setStyle(`colours_${sourceBlock.type.split("_")[0]}`);
+      sourceBlock.setStyle(this.originalStyle);
     }
   }
 }

--- a/src/fields/field_dropdown.js
+++ b/src/fields/field_dropdown.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+class FieldDropdown extends Blockly.FieldDropdown {
+  showEditor_(event) {
+    super.showEditor_(event);
+    const sourceBlock = this.getSourceBlock();
+    if (sourceBlock.isShadow()) {
+      sourceBlock.setColour(sourceBlock.style.colourQuaternary);
+    }
+  }
+
+  dropdownDispose_() {
+    super.dropdownDispose_();
+    const sourceBlock = this.getSourceBlock();
+    if (sourceBlock.isShadow()) {
+      sourceBlock.setStyle(`colours_${sourceBlock.type.split("_")[0]}`);
+    }
+  }
+}
+
+Blockly.fieldRegistry.unregister("field_dropdown");
+Blockly.fieldRegistry.register("field_dropdown", FieldDropdown);

--- a/src/fields/field_variable.js
+++ b/src/fields/field_variable.js
@@ -135,6 +135,22 @@ class FieldVariable extends Blockly.FieldVariable {
     }
     super.onItemSelected_(menu, menuItem);
   }
+
+  showEditor_(event) {
+    super.showEditor_(event);
+    const sourceBlock = this.getSourceBlock();
+    if (sourceBlock.isShadow()) {
+      sourceBlock.setColour(sourceBlock.style.colourQuaternary);
+    }
+  }
+
+  dropdownDispose_() {
+    super.dropdownDispose_();
+    const sourceBlock = this.getSourceBlock();
+    if (sourceBlock.isShadow()) {
+      sourceBlock.setStyle(`colours_${sourceBlock.type.split("_")[0]}`);
+    }
+  }
 }
 
 Blockly.fieldRegistry.unregister("field_variable");

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ import {
 import { CheckableContinuousFlyout } from "./checkable_continuous_flyout.js";
 import { buildGlowFilter, glowStack } from "./glows.js";
 import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
-import { Colours } from "./colours.js";
+import { ScratchTheme } from "./scratch_theme.js";
 import "./scratch_continuous_category.js";
 import "./scratch_comment_icon.js";
 import "./scratch_dragger.js";
@@ -73,7 +73,7 @@ export { contextMenuItems };
 export function inject(container, options) {
   Object.assign(options, {
     renderer: "scratch",
-    theme: "zelos",
+    theme: ScratchTheme,
     plugins: {
       toolbox: ScratchContinuousToolbox,
       flyoutsVerticalToolbox: CheckableContinuousFlyout,
@@ -81,8 +81,6 @@ export function inject(container, options) {
     },
   });
   const workspace = Blockly.inject(container, options);
-
-  Colours.registerBlockStyles();
 
   workspace.getRenderer().getConstants().selectedGlowFilterId = "";
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ import "./events/events_block_comment_delete.js";
 import "./events/events_block_comment_move.js";
 import "./events/events_block_comment_resize.js";
 import "./events/events_scratch_variable_create.js";
+import "./fields/field_dropdown.js";
 import "./fields/field_variable.js";
 import "./fields/field_variable_getter.js";
 import { buildShadowFilter } from "./shadows.js";

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import {
 import { CheckableContinuousFlyout } from "./checkable_continuous_flyout.js";
 import { buildGlowFilter, glowStack } from "./glows.js";
 import { ScratchContinuousToolbox } from "./scratch_continuous_toolbox.js";
+import { Colours } from "./colours.js";
 import "./scratch_continuous_category.js";
 import "./scratch_comment_icon.js";
 import "./scratch_dragger.js";
@@ -55,7 +56,6 @@ export * from "blockly/core";
 export * from "./block_reporting.js";
 export * from "./categories.js";
 export * from "./procedures.js";
-export * from "./colours.js";
 export * from "./fields/field_angle.js";
 export * from "./fields/field_colour_slider.js";
 export * from "./fields/field_matrix.js";
@@ -80,6 +80,9 @@ export function inject(container, options) {
     },
   });
   const workspace = Blockly.inject(container, options);
+
+  Colours.registerBlockStyles();
+
   workspace.getRenderer().getConstants().selectedGlowFilterId = "";
 
   const flyout = workspace.getFlyout();

--- a/src/scratch_theme.js
+++ b/src/scratch_theme.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from "blockly/core";
+
+const blockStyles = {
+  colours_motion: {
+    colourPrimary: "#4C97FF",
+    colourSecondary: "#4280D7",
+    colourTertiary: "#3373CC",
+    colourQuaternary: "#3373CC",
+  },
+  colours_looks: {
+    colourPrimary: "#9966FF",
+    colourSecondary: "#855CD6",
+    colourTertiary: "#774DCB",
+    colourQuaternary: "#774DCB",
+  },
+  colours_sounds: {
+    colourPrimary: "#CF63CF",
+    colourSecondary: "#C94FC9",
+    colourTertiary: "#BD42BD",
+    colourQuaternary: "#BD42BD",
+  },
+  colours_control: {
+    colourPrimary: "#FFAB19",
+    colourSecondary: "#EC9C13",
+    colourTertiary: "#CF8B17",
+    colourQuaternary: "#CF8B17",
+  },
+  colours_event: {
+    colourPrimary: "#FFBF00",
+    colourSecondary: "#E6AC00",
+    colourTertiary: "#CC9900",
+    colourQuaternary: "#CC9900",
+  },
+  colours_sensing: {
+    colourPrimary: "#5CB1D6",
+    colourSecondary: "#47A8D1",
+    colourTertiary: "#2E8EB8",
+    colourQuaternary: "#2E8EB8",
+  },
+  colours_pen: {
+    colourPrimary: "#0fBD8C",
+    colourSecondary: "#0DA57A",
+    colourTertiary: "#0B8E69",
+    colourQuaternary: "#0B8E69",
+  },
+  colours_operators: {
+    colourPrimary: "#59C059",
+    colourSecondary: "#46B946",
+    colourTertiary: "#389438",
+    colourQuaternary: "#389438",
+  },
+  colours_data: {
+    colourPrimary: "#FF8C1A",
+    colourSecondary: "#FF8000",
+    colourTertiary: "#DB6E00",
+    colourQuaternary: "#DB6E00",
+  },
+  colours_data_lists: {
+    colourPrimary: "#FF661A",
+    colourSecondary: "#FF5500",
+    colourTertiary: "#E64D00",
+    colourQuaternary: "#E64D00",
+  },
+  colours_more: {
+    colourPrimary: "#FF6680",
+    colourSecondary: "#FF4D6A",
+    colourTertiary: "#FF3355",
+    colourQuaternary: "#FF3355",
+  },
+  colours_textfield: {
+    colourPrimary: "#FFFFFF",
+    colourSecondary: "#FFFFFF",
+    colourTertiary: "#FFFFFF",
+    colourQuaternary: "#FFFFFF",
+  },
+};
+
+export const ScratchTheme = new Blockly.Theme("scratch", blockStyles);


### PR DESCRIPTION
This PR aligns the styling of dropdown menus with Scratch. This fixes #98. Specifically:

* Dropdown menus take the color of the main block, not the shadow block from whence they spawn
* Shadow dropdown block colors are correct/identical to Scratch, where they had been slightly off
* Removed the white outline on hover on non-shadow dropdown fields
* Where dropdown menu block definitions are being patched by scratch-gui, the no-op block definitions have been removed here

This PR also depends on the related https://github.com/gonfunko/scratch-gui/pull/22.