### PR TITLE
refactor: use an extension to denote monitor blocks

### DIFF
--- a/src/blocks/data.js
+++ b/src/blocks/data.js
@@ -45,9 +45,9 @@ Blockly.Blocks["data_variable"] = {
         "contextMenu_getVariableBlock",
         "colours_data",
         "output_string",
+        "monitor_block",
       ],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -171,9 +171,9 @@ Blockly.Blocks["data_listcontents"] = {
         "contextMenu_getListBlock",
         "colours_data_lists",
         "output_string",
+        "monitor_block",
       ],
     });
-    this.checkboxInFlyout = true;
   },
 };
 

--- a/src/blocks/looks.js
+++ b/src/blocks/looks.js
@@ -282,9 +282,8 @@ Blockly.Blocks["looks_size"] = {
     this.jsonInit({
       message0: Blockly.Msg.LOOKS_SIZE,
       category: Categories.looks,
-      extensions: ["colours_looks", "output_number"],
+      extensions: ["colours_looks", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -474,9 +473,8 @@ Blockly.Blocks["looks_backdropnumbername"] = {
         },
       ],
       category: Categories.looks,
-      extensions: ["colours_looks", "output_number"],
+      extensions: ["colours_looks", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -499,9 +497,8 @@ Blockly.Blocks["looks_costumenumbername"] = {
         },
       ],
       category: Categories.looks,
-      extensions: ["colours_looks", "output_number"],
+      extensions: ["colours_looks", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 

--- a/src/blocks/motion.js
+++ b/src/blocks/motion.js
@@ -374,9 +374,8 @@ Blockly.Blocks["motion_xposition"] = {
     this.jsonInit({
       message0: Blockly.Msg.MOTION_XPOSITION,
       category: Categories.motion,
-      extensions: ["colours_motion", "output_number"],
+      extensions: ["colours_motion", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -389,9 +388,8 @@ Blockly.Blocks["motion_yposition"] = {
     this.jsonInit({
       message0: Blockly.Msg.MOTION_YPOSITION,
       category: Categories.motion,
-      extensions: ["colours_motion", "output_number"],
+      extensions: ["colours_motion", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -404,9 +402,8 @@ Blockly.Blocks["motion_direction"] = {
     this.jsonInit({
       message0: Blockly.Msg.MOTION_DIRECTION,
       category: Categories.motion,
-      extensions: ["colours_motion", "output_number"],
+      extensions: ["colours_motion", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 

--- a/src/blocks/sensing.js
+++ b/src/blocks/sensing.js
@@ -145,9 +145,8 @@ Blockly.Blocks["sensing_answer"] = {
     this.jsonInit({
       message0: Blockly.Msg.SENSING_ANSWER,
       category: Categories.sensing,
-      extensions: ["colours_sensing", "output_number"],
+      extensions: ["colours_sensing", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -309,9 +308,8 @@ Blockly.Blocks["sensing_loudness"] = {
     this.jsonInit({
       message0: Blockly.Msg.SENSING_LOUDNESS,
       category: Categories.sensing,
-      extensions: ["colours_sensing", "output_number"],
+      extensions: ["colours_sensing", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -340,9 +338,8 @@ Blockly.Blocks["sensing_timer"] = {
     this.jsonInit({
       message0: Blockly.Msg.SENSING_TIMER,
       category: Categories.sensing,
-      extensions: ["colours_sensing", "output_number"],
+      extensions: ["colours_sensing", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -394,9 +391,8 @@ Blockly.Blocks["sensing_current"] = {
         },
       ],
       category: Categories.sensing,
-      extensions: ["colours_sensing", "output_number"],
+      extensions: ["colours_sensing", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 
@@ -423,9 +419,8 @@ Blockly.Blocks["sensing_username"] = {
     this.jsonInit({
       message0: Blockly.Msg.SENSING_USERNAME,
       category: Categories.sensing,
-      extensions: ["colours_sensing", "output_number"],
+      extensions: ["colours_sensing", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };
 

--- a/src/blocks/sound.js
+++ b/src/blocks/sound.js
@@ -199,9 +199,7 @@ Blockly.Blocks["sound_volume"] = {
     this.jsonInit({
       message0: Blockly.Msg.SOUND_VOLUME,
       category: Categories.sound,
-      checkboxInFlyout: true,
-      extensions: ["colours_sounds", "output_number"],
+      extensions: ["colours_sounds", "output_number", "monitor_block"],
     });
-    this.checkboxInFlyout = true;
   },
 };

--- a/src/blocks/vertical_extensions.js
+++ b/src/blocks/vertical_extensions.js
@@ -144,6 +144,15 @@ VerticalExtensions.OUTPUT_BOOLEAN = function () {
 };
 
 /**
+ * Extension to make a block a monitor block, capable of reporting its current
+ * value in a dropdown. These blocks also have an accompanying checkbox in the
+ * flyout to toggle display of their current value in a chip on the stage.
+ */
+VerticalExtensions.MONITOR_BLOCK = function () {
+  this.checkboxInFlyout = true;
+};
+
+/**
  * Mixin to add a context menu for a procedure definition block.
  * It adds the "edit" option and removes the "duplicate" option.
  * @mixin
@@ -287,6 +296,11 @@ VerticalExtensions.registerAll = function () {
   Blockly.Extensions.register(
     "scratch_extension",
     VerticalExtensions.SCRATCH_EXTENSION
+  );
+
+  Blockly.Extensions.register(
+    "monitor_block",
+    VerticalExtensions.MONITOR_BLOCK
   );
 };
 

--- a/src/css.js
+++ b/src/css.js
@@ -1003,8 +1003,8 @@ const styles = `
   }
 
   .checked > .blocklyFlyoutCheckbox {
-    fill: var(--colour-motion-primary);
-    stroke: var(--colour-motion-tertiary);
+    fill: var(--colour-toolboxHover);
+    stroke: rgba(0,0,0,0.2);
   }
 
   .blocklyFlyoutCheckboxPath {


### PR DESCRIPTION
This PR refactors the codebase to add the monitor block indicator boolean through an extension. This allows for the monitor block toggle to be round-trippable through block JSON, allowing for extension blocks (defined by the VM) to mark themselves as monitorable.