### PR TITLE
fix: fix the flyout width at 250 pixels

### DIFF
--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -275,6 +275,10 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     return 0.675;
   }
 
+  getWidth() {
+    return 250;
+  }
+
   blockIsRecyclable_(block) {
     const recyclable = super.blockIsRecyclable_(block);
     // Exclude blocks with output connections, because they are able to report their current


### PR DESCRIPTION
This PR fixes the flyout width at 250 pixels, regardless of the size of the largest block it contains. This fixes #153.