### PR TITLE
fix: fix the colors of the angle picker dropdown

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -694,9 +694,7 @@ const styles = `
   }
 
   .blocklyAngleCircle {
-    stroke: var(--colour-motion-tertiary);
     stroke-width: 1;
-    fill: var(--colour-motion-secondary);
   }
 
   .blocklyAngleCenterPoint {

--- a/src/fields/field_angle.js
+++ b/src/fields/field_angle.js
@@ -158,6 +158,8 @@ class FieldAngle extends Blockly.FieldNumber {
         cx: this.HALF,
         cy: this.HALF,
         r: this.RADIUS,
+        fill: this.getSourceBlock().getParent().getColourSecondary(),
+        stroke: this.getSourceBlock().getParent().getColourTertiary(),
         class: "blocklyAngleCircle",
       },
       svg
@@ -248,7 +250,7 @@ class FieldAngle extends Blockly.FieldNumber {
 
     Blockly.DropDownDiv.setColour(
       this.getSourceBlock().getParent().getColour(),
-      this.getSourceBlock().getColourTertiary()
+      this.getSourceBlock().getParent().getColourTertiary()
     );
     Blockly.DropDownDiv.showPositionedByBlock(this, this.getSourceBlock());
 


### PR DESCRIPTION
This PR fixes the display colors used in the angle field dropdown, which were broken by the recent changes to themes.