### PR TITLE
fix: show connection highlights for boolean inputs

### DIFF
--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -9,6 +9,7 @@ import { cssVarify } from "../colours.js";
 
 export class ConstantProvider extends Blockly.zelos.ConstantProvider {
   REPLACEMENT_GLOW_COLOUR = "#ffffff";
+  SELECTED_GLOW_COLOUR = "#ffffff";
 
   /**
    * Sets the visual theme used to render the workspace.

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -23,7 +23,10 @@ export class ScratchRenderer extends Blockly.zelos.Renderer {
   }
 
   shouldHighlightConnection(connection) {
-    return false;
+    return (
+      connection.type === Blockly.ConnectionType.INPUT_VALUE &&
+      connection.getCheck()?.includes("Boolean")
+    );
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue that caused connection highlights to not appear for boolean inputs/blocks. This fixes #156.