### PR TITLE
fix: fix bug that prevented modal dialogs from appearing on mobile

### DIFF
--- a/src/data_category.js
+++ b/src/data_category.js
@@ -426,7 +426,16 @@ function addCreateButton(xmlList, workspace, type) {
   }
   button.setAttribute("text", msg);
   button.setAttribute("callbackKey", callbackKey);
-  workspace.registerButtonCallback(callbackKey, callback);
+  workspace.registerButtonCallback(callbackKey, (b) => {
+    // Run the callback after a delay to avoid it getting captured by the React
+    // modal in scratch-gui and being registered as a click on the scrim that
+    // dismisses the dialog.
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        callback(b);
+      });
+    });
+  });
   xmlList.push(button);
 }
 

--- a/src/procedures.js
+++ b/src/procedures.js
@@ -105,7 +105,14 @@ function addCreateButton_(workspace, xmlList) {
   var msg = Blockly.Msg.NEW_PROCEDURE;
   var callbackKey = "CREATE_PROCEDURE";
   var callback = function () {
-    createProcedureDefCallback(workspace);
+    // Run the callback after a delay to avoid it getting captured by the React
+    // modal in scratch-gui and being registered as a click on the scrim that
+    // dismisses the dialog.
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        createProcedureDefCallback(workspace);
+      });
+    });
   };
   button.setAttribute("text", msg);
   button.setAttribute("callbackKey", callbackKey);


### PR DESCRIPTION
This PR fixes #170. For Reasons, the click event that triggered the display of the new variable/list/procedure modal dialogs was getting captured by React *after* the dialog was opened, and interpreted as a click on the dialog scrim thus dismissing the newly-opened dialog. We now take a moment to allow the event to get flushed out before opening the dialog.