### PR TITLE
fix: allow focusing fields in the flyout on mobile

### DIFF
--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -58,6 +58,7 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     2 * CheckableContinuousFlyout.CHECKBOX_MARGIN;
 
   constructor(workspaceOptions) {
+    workspaceOptions.modalInputs = false;
     super(workspaceOptions);
     this.tabWidth_ = -2;
     this.MARGIN = 12;


### PR DESCRIPTION
This PR prevents using modal dialogs for entering values into fields in the flyout. Unlike core Blockly, Scratch doesn't use modal field editors on mobile, and the flyout wasn't passing this injection option through so https://github.com/gonfunko/scratch-gui/pull/26 doesn't incidentally fix it.