### PR TITLE
fix: fix positioning of categories when scrolling via the toolbox

### DIFF
--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -109,13 +109,18 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     // counted as part of the category for purposes of scrolling to show the
     // category, so we reset/adjust the label gaps used for the scroll position
     // calculation here.
-    this.labelGaps.fill(4);
+    this.labelGaps.fill(
+      this.getWorkspace().getRenderer().getConstants().GRID_UNIT
+    );
   }
 
   calculateBottomPadding(contentMetrics, viewMetrics) {
     // Since we're messing with the alignment by munging the label gaps, we also
     // need to adjust the bottom padding.
-    return super.calculateBottomPadding(contentMetrics, viewMetrics) - 16;
+    return (
+      super.calculateBottomPadding(contentMetrics, viewMetrics) -
+      this.getWorkspace().getRenderer().getConstants().GRID_UNIT * 4
+    );
   }
 
   addBlockListeners_(root, block, rect) {

--- a/src/checkable_continuous_flyout.js
+++ b/src/checkable_continuous_flyout.js
@@ -103,6 +103,21 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
     this.checkboxes_.clear();
   }
 
+  layout_(contents, gaps) {
+    super.layout_(contents, gaps);
+    // We want large gaps between categories (see GAP_Y), but don't want those
+    // counted as part of the category for purposes of scrolling to show the
+    // category, so we reset/adjust the label gaps used for the scroll position
+    // calculation here.
+    this.labelGaps.fill(4);
+  }
+
+  calculateBottomPadding(contentMetrics, viewMetrics) {
+    // Since we're messing with the alignment by munging the label gaps, we also
+    // need to adjust the bottom padding.
+    return super.calculateBottomPadding(contentMetrics, viewMetrics) - 16;
+  }
+
   addBlockListeners_(root, block, rect) {
     if (block.checkboxInFlyout) {
       const coordinates = block.getRelativeToSurfaceXY();


### PR DESCRIPTION
This PR fixes #151 to avoid having too much space atop category labels when jumping to a category via the toolbox.