### PR TITLE
fix: fix color of block reporter dropdown text

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -235,6 +235,7 @@ const styles = `
     text-align: center;
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     font-size: .8em;
+    color: var(--colour-textFieldText);
   }
 
   .blocklyResizeSE {


### PR DESCRIPTION
### Resolves
This PR fixes #192 by aligning the block reporter dropdown's text color with Scratch.