### PR TITLE
fix: fix issue that caused the number/string input in the custom block editor to display square corners

### DIFF
--- a/src/fields/field_textinput_removable.js
+++ b/src/fields/field_textinput_removable.js
@@ -40,26 +40,29 @@ import * as Blockly from "blockly/core";
 export class FieldTextInputRemovable extends Blockly.FieldTextInput {
   /**
    * Show the inline free-text editor on top of the text with the remove button.
-   * @private
    */
   showEditor_() {
-    super.showEditor_();
+    // Wait for our parent block to render so we can examine its metrics to
+    // calculate rounded corners on the editor as needed.
+    Blockly.renderManagement.finishQueuedRenders().then(() => {
+      super.showEditor_();
 
-    const div = Blockly.WidgetDiv.getDiv();
-    div.className += " removableTextInput";
-    const removeButton = document.createElement("img");
-    removeButton.className = "blocklyTextRemoveIcon";
-    removeButton.setAttribute(
-      "src",
-      this.sourceBlock_.workspace.options.pathToMedia + "icons/remove.svg"
-    );
-    this.removeButtonMouseWrapper_ = Blockly.browserEvents.bind(
-      removeButton,
-      "mousedown",
-      this,
-      this.removeCallback_
-    );
-    div.appendChild(removeButton);
+      const div = Blockly.WidgetDiv.getDiv();
+      div.className += " removableTextInput";
+      const removeButton = document.createElement("img");
+      removeButton.className = "blocklyTextRemoveIcon";
+      removeButton.setAttribute(
+        "src",
+        this.sourceBlock_.workspace.options.pathToMedia + "icons/remove.svg"
+      );
+      this.removeButtonMouseWrapper_ = Blockly.browserEvents.bind(
+        removeButton,
+        "mousedown",
+        this,
+        this.removeCallback_
+      );
+      div.appendChild(removeButton);
+    });
   }
 
   /**


### PR DESCRIPTION
This PR fixes #202. The superclass calculates rounded corners based on its height, which was ~1px when a new string/number field is added to a custom block, because it was sized before its host block had fully rendered. On subsequent focus events, the field did have rounded corners as expected. Now, we wait for the next render cycle before showing the editor so that the metrics will always be calculated correctly.