### PR TITLE
fix: make FieldNumber a subclass of FieldTextInput

### DIFF
--- a/src/fields/field_number.js
+++ b/src/fields/field_number.js
@@ -45,7 +45,7 @@ import { Colours } from "../colours.js";
  * @extends {Blockly.FieldTextInput}
  * @constructor
  */
-class FieldNumberPicker extends Blockly.FieldNumber {
+class FieldNumberPicker extends Blockly.FieldTextInput {
   /**
    * Fixed width of the num-pad drop-down, in px.
    * @type {number}


### PR DESCRIPTION
This PR fixes #203 and fixes #157. Our FieldNumber was previously a subclass of core Blockly's FieldNumber, but this had a side effect of making it more restrictive than Scratch. Now, our FieldNumber is a subclass of FieldTextInput. This does mean that it accepts invalid values like -..--35 (generally anything involving characters that could be legal in a numeric value), but this is consistent with Scratch's behavior, and the VM is robust to it, evaluating invalid values to 0.