### PR TITLE
fix: improve sizing and rendering of comments

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -524,6 +524,9 @@ const styles = `
     stroke-width: 3px;
   }
 
+  .blocklyCommentText::placeholder {
+    font-style: italic;
+  }
 
   .blocklyCommentTextarea {
     background-color: #fef49c;

--- a/src/index.js
+++ b/src/index.js
@@ -129,3 +129,7 @@ Blockly.ContextMenuRegistry.registry.unregister("blockDelete");
 contextMenuItems.registerDeleteBlock();
 Blockly.ContextMenuRegistry.registry.unregister("workspaceDelete");
 contextMenuItems.registerDeleteAll();
+Blockly.comments.CommentView.defaultCommentSize = new Blockly.utils.Size(
+  200,
+  200
+);

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -17,6 +17,7 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     this.sourceBlock = sourceBlock;
     this.disposing = false;
     this.id = Blockly.utils.idGenerator.genUid();
+    this.setPlaceholderText(Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
     this.getSvgRoot().setAttribute(
       "style",
       `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`


### PR DESCRIPTION
### Resolves
This PR fixes #189 and fixes #190. It adds true placeholder text to block/workspace comments and defaults them to the same size that Scratch uses.