### PR TITLE
fix: fix alignment of "define" text baseline on custom blocks

### DIFF
--- a/src/renderer/render_info.js
+++ b/src/renderer/render_info.js
@@ -78,7 +78,7 @@ export class RenderInfo extends Blockly.zelos.RenderInfo {
 
   getElemCenterline_(row, elem) {
     if (this.isBowlerHatBlock() && Blockly.blockRendering.Types.isField(elem)) {
-      return row.yPos + elem.height;
+      return row.yPos + row.height / 2;
     } else if (
       this.block_.isScratchExtension &&
       Blockly.blockRendering.Types.isField(elem) &&


### PR DESCRIPTION
This PR fixes the alignment of the "define" text's baseline relative to the baseline on the prototype caller block inside of a custom block definition block. This fixes #194.