### PR TITLE
refactor: Add support for Typescript

### DIFF
--- a/continuous-toolbox.d.ts
+++ b/continuous-toolbox.d.ts
@@ -1,0 +1,1 @@
+declare module "@blockly/continuous-toolbox";

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@commitlint/config-conventional": "^17.8.1",
         "eslint": "^4.19.1",
         "source-map-loader": "^4.0.1",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.6.3",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
@@ -6222,6 +6224,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -6309,9 +6340,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11903,6 +11934,27 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "ts-loader": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        }
+      }
+    },
     "ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -11956,9 +12008,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@commitlint/config-conventional": "^17.8.1",
     "eslint": "^4.19.1",
     "source-map-loader": "^4.0.1",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.6.3",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export {
   StatusButtonState,
 } from "./status_indicator_label.js";
 
-export function inject(container, options) {
+export function inject(container: Element, options: Blockly.BlocklyOptions) {
   registerFieldAngle();
   registerFieldColourSlider();
   registerFieldDropdown();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "noImplicitAny": true,
+    "module": "es6",
+    "target": "es6",
+    "allowJs": true,
+    "moduleResolution": "node"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,36 +1,48 @@
-const path = require('path');
+const path = require("path");
 
 // Base config that applies to either development or production mode.
 const config = {
-  entry: './src/index.js',
+  entry: "./src/index.js",
   output: {
-    library: 'ScratchBlocks',
-    libraryTarget: 'commonjs2',
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js'
+    library: "ScratchBlocks",
+    libraryTarget: "commonjs2",
+    path: path.resolve(__dirname, "dist"),
+    filename: "[name].js",
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
   },
   // Enable webpack-dev-server to get hot refresh of the app.
   devServer: {
-    static: './build',
+    static: "./build",
   },
 };
 
 module.exports = (env, argv) => {
-  if (argv.mode === 'development') {
+  if (argv.mode === "development") {
     // Set the output path to the `build` directory
     // so we don't clobber production builds.
-    config.output.path = path.resolve(__dirname, 'build');
+    config.output.path = path.resolve(__dirname, "build");
 
     // Generate source maps for our code for easier debugging.
     // Not suitable for production builds. If you want source maps in
     // production, choose a different one from https://webpack.js.org/configuration/devtool
-    config.devtool = 'eval-cheap-module-source-map';
+    config.devtool = "eval-cheap-module-source-map";
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
       test: /(blockly\/.*\.js)$/,
-      use: [require.resolve('source-map-loader')],
-      enforce: 'pre',
+      use: [require.resolve("source-map-loader")],
+      enforce: "pre",
     });
 
     // Ignore spurious warnings from source-map-loader

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 // Base config that applies to either development or production mode.
 const config = {
-  entry: "./src/index.js",
+  entry: "./src/index.ts",
   output: {
     library: "ScratchBlocks",
     libraryTarget: "commonjs2",


### PR DESCRIPTION
This PR sets up minimal infrastructure for using Typescript, and converts the entry point to Typescript. It should now be possible to write new files in TS or convert existing ones without taking any special steps beyond using the .ts extension and writing valid Typescript.