### PR TITLE
refactor: use IDs based on the parent block ID for block comments

### DIFF
--- a/src/scratch_block_paster.ts
+++ b/src/scratch_block_paster.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Blockly from "blockly/core";
+import type { ScratchCommentIcon } from "./scratch_comment_icon";
 
 /**
  * Class responsible for handling the pasting of copied blocks.
@@ -29,6 +30,15 @@ class ScratchBlockPaster extends Blockly.clipboard.BlockPaster {
       block?.type === "argument_reporter_string_number"
     ) {
       block.setDragStrategy(new Blockly.dragging.BlockDragStrategy(block));
+    }
+
+    // Deserialization of blocks suppresses events, so even though this gets
+    // fired for blocks with comments, the VM will never receive it, causing its
+    // state to get out of sync. Manually fire it here (after suppression has
+    // been turned off) if needed.
+    const commentIcon = block.getIcon(Blockly.icons.IconType.COMMENT);
+    if (commentIcon) {
+      (commentIcon as ScratchCommentIcon).fireCreateEvent();
     }
 
     return block;

--- a/src/scratch_comment_bubble.js
+++ b/src/scratch_comment_bubble.js
@@ -16,7 +16,7 @@ export class ScratchCommentBubble extends Blockly.comments.CommentView {
     super(sourceBlock.workspace);
     this.sourceBlock = sourceBlock;
     this.disposing = false;
-    this.id = Blockly.utils.idGenerator.genUid();
+    this.id = `${sourceBlock.id}_comment`;
     this.setPlaceholderText(Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
     this.getSvgRoot().setAttribute(
       "style",

--- a/src/scratch_comment_icon.ts
+++ b/src/scratch_comment_icon.ts
@@ -19,7 +19,7 @@ interface CommentState {
 /**
  * Custom comment icon that draws no icon indicator, used for block comments.
  */
-class ScratchCommentIcon
+export class ScratchCommentIcon
   extends Blockly.icons.Icon
   implements Blockly.ISerializable, Blockly.IHasBubble
 {
@@ -34,9 +34,7 @@ class ScratchCommentIcon
   constructor(protected sourceBlock: Blockly.BlockSvg) {
     super(sourceBlock);
     this.commentBubble = new ScratchCommentBubble(this.sourceBlock);
-    Blockly.Events.fire(
-      new (Blockly.Events.get("block_comment_create"))(this.commentBubble)
-    );
+    this.fireCreateEvent();
     this.onTextChangedListener = this.onTextChanged.bind(this);
     this.onSizeChangedListener = this.onSizeChanged.bind(this);
     this.onCollapseListener = this.onCollapsed.bind(this);
@@ -201,6 +199,15 @@ class ScratchCommentIcon
   dispose() {
     this.commentBubble.dispose();
     super.dispose();
+  }
+
+  /**
+   * Fires a block comment create event corresponding to this icon's comment.
+   */
+  fireCreateEvent() {
+    Blockly.Events.fire(
+      new (Blockly.Events.get("block_comment_create"))(this.commentBubble)
+    );
   }
 }
 


### PR DESCRIPTION
### Resolves
This PR builds towards resolving #84. Built-in Blockly block comments do not have IDs, because they're just represented as part of the block. Scratch's old implementation did have IDs, which get serialized and are tracked by the VM to maintain its internal state in response to block comment events.

This change makes block comment IDs the same as their parent block's ID with `_comment` suffix. In partnership with a forthcoming PR in -vm, this will allow for consistent comment IDs between -blocks and -vm, which in turn fixes the interop issues described in #84.

Additionally, this PR fixes a bug that could cause the workspace and VM state to get out of sync due to events fired during block deserialization being suppressed.