### PR TITLE
Don't render checkbox bubble if block has a parent.

### DIFF
--- a/src/flyout_checkbox_icon.ts
+++ b/src/flyout_checkbox_icon.ts
@@ -15,7 +15,7 @@ export class FlyoutCheckboxIcon implements Blockly.IIcon, Blockly.IHasBubble {
   private type = new Blockly.icons.IconType("checkbox");
 
   constructor(private sourceBlock: Blockly.BlockSvg) {
-    if (this.sourceBlock.workspace.isFlyout) {
+    if (this.sourceBlock.workspace.isFlyout && !this.sourceBlock.getParent()) {
       this.checkboxBubble = new CheckboxBubble(this.sourceBlock);
     }
   }


### PR DESCRIPTION
I don't know if this is the right spot but, I may as well try.

This prevents weird overlapping when adding XML to the toolbox where the reporter has the "monitor_block" extension but is inside another block at the same time.