### PR TITLE
fix: fix bug that could cause the wrong toolbox category to appear selected

### DIFF
--- a/src/checkable_continuous_flyout.ts
+++ b/src/checkable_continuous_flyout.ts
@@ -109,4 +109,8 @@ export class CheckableContinuousFlyout extends ContinuousFlyout {
       }
     }
   }
+
+  scrollTo(position: number) {
+    super.scrollTo(Math.ceil(position));
+  }
 }


### PR DESCRIPTION
This PR fixes an issue that could cause the wrong toolbox category to become selected after clicking one due to subpixel position values.