### PR TITLE
fix: prevent toolbox categories from becoming unselected

### DIFF
--- a/src/scratch_continuous_toolbox.ts
+++ b/src/scratch_continuous_toolbox.ts
@@ -67,4 +67,20 @@ export class ScratchContinuousToolbox extends ContinuousToolbox {
   runAfterRerender(callback: () => void) {
     this.postRenderCallbacks.push(callback);
   }
+
+  /**
+   * Returns whether or not the given item should be deselected.
+   * Prevents items from being deselected without a replacement.
+   *
+   * @param oldItem The item that was previously selected.
+   * @param newItem The item that is proposed to be selected instead.
+   * @returns True if the old item should be allowed to be deselected.
+   */
+  shouldDeselectItem_(
+    oldItem: Blockly.ISelectableToolboxItem | null,
+    newItem: Blockly.ISelectableToolboxItem | null
+  ) {
+    if (!newItem) return false;
+    return super.shouldDeselectItem_(oldItem, newItem);
+  }
 }


### PR DESCRIPTION
This ensures that a toolbox category is always displayed as selected, even if focus moves somewhere else.