### PR TITLE
chore: Update dependencies to the latest version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@blockly/continuous-toolbox": "^7.0.1",
-        "@blockly/field-colour": "^6.0.1",
-        "blockly": "^12.1.0"
+        "@blockly/field-colour": "^6.0.3",
+        "blockly": "^12.2.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
@@ -156,12 +156,27 @@
       }
     },
     "node_modules/@blockly/field-colour": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.1.tgz",
-      "integrity": "sha512-q6syoHjXlLfIoXTFhgE95Wrxbj38lKBLYQTnS1J/J67Efik35+L4E9uzGKaO9n8aLk7r6qiho4hZjOqE/Am3HA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.3.tgz",
+      "integrity": "sha512-yToG4pYxYqYz4RpKkOkYbW1pimw1OdHNPTGj7hFWET63FekQPoC1sdt7BT5gj2s07wBWagA6k8f4SYS8uKGqGw==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@blockly/field-grid-dropdown": "^6.0.2"
+      },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/field-grid-dropdown": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.2.tgz",
+      "integrity": "sha512-eMtLY296n3i55EDd+8YHtnb1IpE6tesGGzSyPftlK1JEw5otBU+PLOTMORTqtaZX2KHc37dwOJcV51fEswd/qg==",
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^12.0.0"
@@ -1465,9 +1480,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.1.0.tgz",
-      "integrity": "sha512-J9OMcMVR1HaqqRf3WJJpLBUHh4hy3Ma7JQoMZruRH7evS3kxrihHodVFOuqQzRvHtBtTtcQjzVLZog+0vpB58g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.2.0.tgz",
+      "integrity": "sha512-s4QL9ogEMzc4Pxfe8Oi3Kmu6SQ0ts2thzmRYjdnMSEIVZFpBZ4OUuNKvpFICqujO0yfAo99zON8KzxAFw8hA1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "26.1.0"
@@ -7266,9 +7281,17 @@
       "requires": {}
     },
     "@blockly/field-colour": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.1.tgz",
-      "integrity": "sha512-q6syoHjXlLfIoXTFhgE95Wrxbj38lKBLYQTnS1J/J67Efik35+L4E9uzGKaO9n8aLk7r6qiho4hZjOqE/Am3HA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.3.tgz",
+      "integrity": "sha512-yToG4pYxYqYz4RpKkOkYbW1pimw1OdHNPTGj7hFWET63FekQPoC1sdt7BT5gj2s07wBWagA6k8f4SYS8uKGqGw==",
+      "requires": {
+        "@blockly/field-grid-dropdown": "^6.0.2"
+      }
+    },
+    "@blockly/field-grid-dropdown": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.2.tgz",
+      "integrity": "sha512-eMtLY296n3i55EDd+8YHtnb1IpE6tesGGzSyPftlK1JEw5otBU+PLOTMORTqtaZX2KHc37dwOJcV51fEswd/qg==",
       "requires": {}
     },
     "@commitlint/cli": {
@@ -8309,9 +8332,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.1.0.tgz",
-      "integrity": "sha512-J9OMcMVR1HaqqRf3WJJpLBUHh4hy3Ma7JQoMZruRH7evS3kxrihHodVFOuqQzRvHtBtTtcQjzVLZog+0vpB58g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.2.0.tgz",
+      "integrity": "sha512-s4QL9ogEMzc4Pxfe8Oi3Kmu6SQ0ts2thzmRYjdnMSEIVZFpBZ4OUuNKvpFICqujO0yfAo99zON8KzxAFw8hA1w==",
       "requires": {
         "jsdom": "26.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@blockly/continuous-toolbox": "^7.0.1",
-    "@blockly/field-colour": "^6.0.1",
-    "blockly": "^12.1.0"
+    "@blockly/field-colour": "^6.0.3",
+    "blockly": "^12.2.0"
   }
 }

--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -22,10 +22,11 @@ export class ScratchCommentBubble
   private dragStartLocation?: Blockly.utils.Coordinate;
 
   constructor(sourceBlock: Blockly.BlockSvg) {
-    super(sourceBlock.workspace);
+    const commentId = `${sourceBlock.id}_comment`;
+    super(sourceBlock.workspace, commentId);
     this.sourceBlock = sourceBlock;
     this.disposing = false;
-    this.id = `${sourceBlock.id}_comment`;
+    this.id = commentId;
     this.setPlaceholderText(Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT);
     this.getSvgRoot().setAttribute(
       "style",


### PR DESCRIPTION
This PR updates the Blockly-related dependencies to their latest versions and fixes #238 and fixes #241.