### PR TITLE
fix: fix ephemeral focus handling for `FieldAngle` and `FieldNote`

### DIFF
--- a/src/fields/field_note.ts
+++ b/src/fields/field_note.ts
@@ -286,7 +286,7 @@ export class FieldNote extends Blockly.FieldTextInput {
    * Show a field with piano keys.
    */
   showEditor_(event: PointerEvent, quietInput = false) {
-    super.showEditor_(event, quietInput);
+    super.showEditor_(event, quietInput, false);
 
     // Build the SVG DOM.
     const div = Blockly.DropDownDiv.getContentDiv();

--- a/src/fields/scratch_field_angle.ts
+++ b/src/fields/scratch_field_angle.ts
@@ -157,7 +157,15 @@ class ScratchFieldAngle extends Blockly.FieldNumber {
    * Show the inline free-text editor on top of the text.
    */
   showEditor_(event: PointerEvent) {
-    super.showEditor_(event);
+    // Mobile browsers have issues with in-line textareas (focus & keyboards).
+    // Also, don't let the parent take ephemeral focus since the drop-down div
+    // below will handle it, instead.
+    const noFocus =
+      Blockly.utils.userAgent.MOBILE ||
+      Blockly.utils.userAgent.ANDROID ||
+      Blockly.utils.userAgent.IPAD;
+    super.showEditor_(event, noFocus, false);
+
     // If there is an existing drop-down someone else owns, hide it immediately and clear it.
     Blockly.DropDownDiv.hideWithoutAnimation();
     Blockly.DropDownDiv.clearContent();


### PR DESCRIPTION
This PR fixes #239 by not having the `FieldNumber` superclass of these two fields handle ephemeral focus in favor of letting the `DropDownDiv` do so. 