### PR TITLE
fix: improve styling, especially in high contrast mode

### DIFF
--- a/src/colours.ts
+++ b/src/colours.ts
@@ -53,6 +53,7 @@ const Colours = {
   valueReportBackground: "#FFFFFF",
   valueReportBorder: "#AAAAAA",
   contextualMenuHover: "rgba(77, 151, 255, .25)",
+  menuHover: "rgba(0, 0, 0, .2)",
 };
 
 /**

--- a/src/css.ts
+++ b/src/css.ts
@@ -702,16 +702,16 @@ const styles = `
   }
 
   .blocklyAngleCenterPoint {
-    stroke: #fff;
+    stroke: var(--colour-text);
     stroke-width: 1;
-    fill: #fff;
+    fill: var(--colour-text);
   }
 
   .blocklyAngleDragHandle {
-    stroke: #fff;
+    stroke: var(--colour-text);
     stroke-width: 5;
     stroke-opacity: 0.25;
-    fill: #fff;
+    fill: var(--colour-text);
     cursor: pointer;
   }
 
@@ -720,18 +720,18 @@ const styles = `
   }
 
   .blocklyAngleMarks {
-    stroke: #fff;
+    stroke: var(--colour-text);
     stroke-width: 1;
     stroke-opacity: 0.5;
   }
 
   .blocklyAngleGauge {
-    fill: #fff;
+    fill: var(--colour-text);
     fill-opacity: 0.20;
   }
 
   .blocklyAngleLine {
-    stroke: #fff;
+    stroke: var(--colour-text);
     stroke-width: 1;
     stroke-linecap: round;
     pointer-events: none;

--- a/src/css.ts
+++ b/src/css.ts
@@ -1011,12 +1011,12 @@ const styles = `
     z-index: 20000;  /* Arbitrary, but some apps depend on it... */
   }
 
-  .blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover {
-    background: var(--colour-menuHover);
+  .blocklyDropDownDiv .blocklyMenu .blocklyMenuItem.blocklyMenuItemHighlight {
+    background-color: var(--colour-menuHover);
   }
 
-  .blocklyWidgetDiv .blocklyMenu .blocklyMenuItem:hover {
-    background: var(--colour-contextualMenuHover);
+  .blocklyWidgetDiv .blocklyMenu .blocklyMenuItem.blocklyMenuItemHighlight {
+    background-color: var(--colour-contextualMenuHover);
   }
 
   .blocklyWidgetDiv .blocklyMenu .blocklyMenuItemDisabled.blocklyMenuItem:hover {
@@ -1168,13 +1168,12 @@ const styles = `
     color: #4c97ff;
   }
   .blocklyDropDownDiv .blocklyMenuItem {
-    color: #fff;
     font-weight: bold;
     min-height: 32px;
     padding: 4px 7em 4px 28px;
   }
-  .high-contrast-theme.blocklyDropDownDiv .blocklyMenuItem {
-    color: #000;
+  .scratch-renderer.blocklyDropDownDiv .blocklyMenuItem .blocklyMenuItemContent {
+    color: var(--colour-text);
   }
   .blocklyToolboxSelected .blocklyTreeLabel {
     color: var(--colour-toolboxText);

--- a/src/fields/field_matrix.ts
+++ b/src/fields/field_matrix.ts
@@ -215,7 +215,7 @@ class FieldMatrix extends Blockly.Field<string> {
       this.arrow_.setAttributeNS(
         "http://www.w3.org/1999/xlink",
         "xlink:href",
-        Blockly.getMainWorkspace().options.pathToMedia + "dropdown-arrow.svg"
+        this.getConstants().FIELD_DROPDOWN_SVG_ARROW_DATAURI
       );
       this.arrow_.style.cursor = "default";
     }
@@ -238,6 +238,25 @@ class FieldMatrix extends Blockly.Field<string> {
    * Show the drop-down menu for editing this field.
    */
   showEditor_() {
+    const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
+    Blockly.DropDownDiv.setColour(
+      sourceBlock.getColour(),
+      sourceBlock.getColourTertiary()
+    );
+
+    const style = sourceBlock.style;
+    if (sourceBlock.isShadow()) {
+      this.originalStyle = sourceBlock.getStyleName();
+      sourceBlock.setStyle(`${this.originalStyle}_selected`);
+    } else if (this.borderRect_) {
+      this.borderRect_.setAttribute(
+        "fill",
+        "colourQuaternary" in style
+          ? `${style.colourQuaternary}`
+          : style.colourTertiary
+      );
+    }
+
     const div = Blockly.DropDownDiv.getContentDiv();
     // Build the SVG DOM.
     const matrixSize =
@@ -286,23 +305,19 @@ class FieldMatrix extends Blockly.Field<string> {
     // Button to clear matrix
     const clearButtonDiv = document.createElement("div");
     clearButtonDiv.className = "scratchMatrixButtonDiv";
-    const sourceBlock = this.getSourceBlock() as Blockly.BlockSvg;
+
     const clearButton = this.createButton_(sourceBlock.getColourSecondary());
     clearButtonDiv.appendChild(clearButton);
     // Button to fill matrix
     const fillButtonDiv = document.createElement("div");
     fillButtonDiv.className = "scratchMatrixButtonDiv";
-    const fillButton = this.createButton_("#FFFFFF");
+    const fillButton = this.createButton_("var(--colour-text)");
     fillButtonDiv.appendChild(fillButton);
 
     buttonDiv.appendChild(clearButtonDiv);
     buttonDiv.appendChild(fillButtonDiv);
     div.appendChild(buttonDiv);
 
-    Blockly.DropDownDiv.setColour(
-      sourceBlock.getColour(),
-      sourceBlock.getColourTertiary()
-    );
     Blockly.DropDownDiv.showPositionedByBlock(
       this,
       sourceBlock,
@@ -328,19 +343,6 @@ class FieldMatrix extends Blockly.Field<string> {
       this.fillMatrix_
     );
 
-    const style = sourceBlock.style;
-    if (sourceBlock.isShadow()) {
-      this.originalStyle = sourceBlock.getStyleName();
-      sourceBlock.setStyle(`${this.originalStyle}_selected`);
-    } else if (this.borderRect_) {
-      this.borderRect_.setAttribute(
-        "fill",
-        "colourQuaternary" in style
-          ? `${style.colourQuaternary}`
-          : style.colourTertiary
-      );
-    }
-
     // Update the matrix for the current value
     this.updateMatrix_();
   }
@@ -350,6 +352,7 @@ class FieldMatrix extends Blockly.Field<string> {
     if (sourceBlock.isShadow()) {
       sourceBlock.setStyle(this.originalStyle);
     }
+    this.updateMatrix_();
   }
 
   /**
@@ -400,12 +403,16 @@ class FieldMatrix extends Blockly.Field<string> {
         this.fillMatrixNode_(
           this.ledButtons_,
           i,
+          sourceBlock.getColourTertiary()
+        );
+        this.fillMatrixNode_(
+          this.ledThumbNodes_,
+          i,
           sourceBlock.getColourSecondary()
         );
-        this.fillMatrixNode_(this.ledThumbNodes_, i, sourceBlock.getColour());
       } else {
-        this.fillMatrixNode_(this.ledButtons_, i, "#FFFFFF");
-        this.fillMatrixNode_(this.ledThumbNodes_, i, "#FFFFFF");
+        this.fillMatrixNode_(this.ledButtons_, i, "var(--colour-text)");
+        this.fillMatrixNode_(this.ledThumbNodes_, i, "var(--colour-text)");
       }
     }
   }
@@ -505,10 +512,14 @@ class FieldMatrix extends Blockly.Field<string> {
    * Unbind mouse move event and clear the paint style.
    */
   onMouseUp() {
-    Blockly.browserEvents.unbind(this.matrixMoveWrapper_);
-    this.matrixMoveWrapper_ = null;
-    Blockly.browserEvents.unbind(this.matrixReleaseWrapper_);
-    this.matrixReleaseWrapper_ = null;
+    if (this.matrixMoveWrapper_) {
+      Blockly.browserEvents.unbind(this.matrixMoveWrapper_);
+      this.matrixMoveWrapper_ = null;
+    }
+    if (this.matrixReleaseWrapper_) {
+      Blockly.browserEvents.unbind(this.matrixReleaseWrapper_);
+      this.matrixReleaseWrapper_ = null;
+    }
     this.paintStyle_ = null;
   }
 


### PR DESCRIPTION
This PR fixes #52 and fixes #240. It also makes general improvements to the styling of menus. `FieldMatrix` and `FieldAngle` now slightly skew from Scratch, but in what I think are more accessible and consistent ways: The `FieldAngle` circle background color is not hardcoded to the main theme's blue block color (it inherits its color), and it uses black tick marks/lines in the high contrast theme, consistent with the color used for text in that theme. `FieldMatrix` now uses more visible colors in the high contrast theme, and the small preview of the matrix in the field cell draws non-active cells with the field's background color to make the intended bitmap image more readily visible.

Spork fields:
<img width="189" height="192" alt="spork_angle_default" src="https://github.com/user-attachments/assets/29b98709-4e97-403a-87f2-5fd89512f5c2" />
<img width="187" height="191" alt="spork_angle_hc" src="https://github.com/user-attachments/assets/2fd3d12f-d74f-43fe-bdf5-4db0c2152bec" />
<img width="188" height="211" alt="spork_matrix_hc" src="https://github.com/user-attachments/assets/543d2c21-70f2-4848-82f3-1de072edb238" />
<img width="187" height="211" alt="spork_matrix_default" src="https://github.com/user-attachments/assets/3ba49ae7-9656-4ed2-af15-2c014e95cc18" />

Scratch fields:
<img width="185" height="190" alt="scratch_angle_default" src="https://github.com/user-attachments/assets/1bce1144-d922-4f2d-b75a-e50521b5b97a" />
<img width="188" height="198" alt="scratch_angle_hc" src="https://github.com/user-attachments/assets/bfce5d52-e49d-4443-af72-43f7a6573101" />
<img width="183" height="216" alt="scratch_matrix_hc" src="https://github.com/user-attachments/assets/24f9fe0e-498f-4e8e-8b1d-690d1dcaad68" />
<img width="184" height="217" alt="scratch_matrix_default" src="https://github.com/user-attachments/assets/fb5f94e0-7d92-4686-b3bf-1b0a65cceedf" />
