### PR TITLE
fix: fix bug that could clear the values of procedure block caller arguments

### DIFF
--- a/src/blocks/procedures.ts
+++ b/src/blocks/procedures.ts
@@ -224,7 +224,7 @@ function disconnectOldBlocks_(this: ProcedureBlock): ConnectionMap {
     if (input.connection) {
       const target = input.connection.targetBlock() as Blockly.BlockSvg;
       const saveInfo = {
-        shadow: input.connection.getShadowDom(),
+        shadow: input.connection.getShadowDom(true),
         block: target,
       };
       connectionMap[input.name] = saveInfo;


### PR DESCRIPTION
This PR fixes #228. It requests that, when shadow blocks in procedure caller blocks are stashed before reloading the inputs on the caller block after editing the procedure definition, that the shadow DOM be generated afresh rather than using the cached value. This fixes a bug that caused fields in procedure caller blocks to temporarily lose their values after editing the procedure.