### PR TITLE
fix: fix bug that prevented moving block comments

### DIFF
--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -32,6 +32,7 @@ export class ScratchCommentBubble
       "style",
       `--colour-commentBorder: ${sourceBlock.getColourTertiary()};`
     );
+    this.getSvgRoot().setAttribute("id", this.id);
 
     Blockly.browserEvents.conditionalBind(
       this.getSvgRoot(),


### PR DESCRIPTION
This PR fixes a bug that prevented dragging workspace comments by their titlebar to move them. The focus manager requires that things gaining focus have an ID, and the comment's top bar did not.