### PR TITLE
fix: fix positioning of block comments in RTL mode

### DIFF
--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -129,14 +129,17 @@ export class ScratchCommentBubble
   }
 
   dropAnchor() {
-    this.moveTo(this.anchor.x + 40, this.anchor.y - 16);
+    this.moveTo(
+      this.anchor.x + 40 * (this.workspace.RTL ? -1 : 1),
+      this.anchor.y - 16
+    );
     const location = this.getRelativeToSurfaceXY();
     this.anchorChain = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.LINE,
       {
         x1: this.anchor.x - location.x,
         y1: this.anchor.y - location.y,
-        x2: this.getSize().width / 2,
+        x2: (this.getSize().width / 2) * (this.workspace.RTL ? -1 : 1),
         y2: 16,
         style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
       },

--- a/src/scratch_comment_bubble.ts
+++ b/src/scratch_comment_bubble.ts
@@ -129,9 +129,10 @@ export class ScratchCommentBubble
   }
 
   dropAnchor() {
+    const verticalOffset = 16;
     this.moveTo(
       this.anchor.x + 40 * (this.workspace.RTL ? -1 : 1),
-      this.anchor.y - 16
+      this.anchor.y - verticalOffset
     );
     const location = this.getRelativeToSurfaceXY();
     this.anchorChain = Blockly.utils.dom.createSvgElement(
@@ -140,7 +141,7 @@ export class ScratchCommentBubble
         x1: this.anchor.x - location.x,
         y1: this.anchor.y - location.y,
         x2: (this.getSize().width / 2) * (this.workspace.RTL ? -1 : 1),
-        y2: 16,
+        y2: verticalOffset,
         style: `stroke: ${this.sourceBlock.getColourTertiary()}; stroke-width: 1`,
       },
       this.getSvgRoot()


### PR DESCRIPTION
This PR fixes the positioning of block comments on RTL workspaces, as noted in https://github.com/scratchfoundation/scratch-editor/pull/214#issuecomment-2891987266.