### PR TITLE
fix: make Duplicate context menu item duplicate subsequent blocks

### DIFF
--- a/src/context_menu_items.ts
+++ b/src/context_menu_items.ts
@@ -154,3 +154,27 @@ function deleteNext(deleteList: Blockly.BlockSvg[], eventGroup?: string) {
   }
   Blockly.Events.setGroup(false);
 }
+
+/**
+ * Registers a block duplicate option that duplicates the selected block and
+ * all subsequent blocks in the stack.
+ */
+export function registerDuplicateBlock() {
+  const original =
+    Blockly.ContextMenuRegistry.registry.getItem("blockDuplicate");
+  const duplicateOption = {
+    displayText: original.displayText,
+    preconditionFn: original.preconditionFn,
+    callback(scope: Blockly.ContextMenuRegistry.Scope) {
+      if (!scope.block) return;
+      const data = scope.block.toCopyData(true);
+      if (!data) return;
+      Blockly.clipboard.paste(data, scope.block.workspace);
+    },
+    scopeType: original.scopeType,
+    id: original.id,
+    weight: original.weight,
+  };
+  Blockly.ContextMenuRegistry.registry.unregister(duplicateOption.id);
+  Blockly.ContextMenuRegistry.registry.register(duplicateOption);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ Blockly.ContextMenuRegistry.registry.unregister("blockInline");
 Blockly.ContextMenuItems.registerCommentOptions();
 Blockly.ContextMenuRegistry.registry.unregister("blockDelete");
 contextMenuItems.registerDeleteBlock();
+contextMenuItems.registerDuplicateBlock();
 Blockly.ContextMenuRegistry.registry.unregister("workspaceDelete");
 contextMenuItems.registerDeleteAll();
 Blockly.comments.CommentView.defaultCommentSize = new Blockly.utils.Size(


### PR DESCRIPTION
This PR fixes #237. It modifies the Duplicate contextual menu command to include the selected block and all subsequent blocks, but otherwise defer to the built-in command. This depends on an as-yet-unreleased version of Blockly that includes https://github.com/google/blockly/pull/9279.