### PR TITLE
chore: update to latest version of Blockly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@blockly/continuous-toolbox": "^7.0.1",
         "@blockly/field-colour": "^6.0.3",
-        "blockly": "^12.2.0"
+        "blockly": "^12.3.0-beta.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
@@ -170,10 +170,10 @@
         "blockly": "^12.0.0"
       }
     },
-    "node_modules/@blockly/field-grid-dropdown": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.2.tgz",
-      "integrity": "sha512-eMtLY296n3i55EDd+8YHtnb1IpE6tesGGzSyPftlK1JEw5otBU+PLOTMORTqtaZX2KHc37dwOJcV51fEswd/qg==",
+    "node_modules/@blockly/field-colour/node_modules/@blockly/field-grid-dropdown": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.3.tgz",
+      "integrity": "sha512-BeCmxNz4FuvZ9GRTw+RM8jWADK2DhQupacKRdhFlEnhR9akOSTwIgeaWoqnIvBkLvXLtSwAJTuQG5wyXoGGd0A==",
       "license": "Apache 2.0",
       "engines": {
         "node": ">=8.17.0"
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.2.0.tgz",
-      "integrity": "sha512-s4QL9ogEMzc4Pxfe8Oi3Kmu6SQ0ts2thzmRYjdnMSEIVZFpBZ4OUuNKvpFICqujO0yfAo99zON8KzxAFw8hA1w==",
+      "version": "12.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.0-beta.0.tgz",
+      "integrity": "sha512-QXD6dXbsYFLzBs9umZRDhpllkM3Mdxtc9JnDMKksLzEFdFbl2CDl2JaKaw/rP5B0InpD1UrZPF7xT1ZRvJLS9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "26.1.0"
@@ -7286,13 +7286,15 @@
       "integrity": "sha512-yToG4pYxYqYz4RpKkOkYbW1pimw1OdHNPTGj7hFWET63FekQPoC1sdt7BT5gj2s07wBWagA6k8f4SYS8uKGqGw==",
       "requires": {
         "@blockly/field-grid-dropdown": "^6.0.2"
+      },
+      "dependencies": {
+        "@blockly/field-grid-dropdown": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.3.tgz",
+          "integrity": "sha512-BeCmxNz4FuvZ9GRTw+RM8jWADK2DhQupacKRdhFlEnhR9akOSTwIgeaWoqnIvBkLvXLtSwAJTuQG5wyXoGGd0A==",
+          "requires": {}
+        }
       }
-    },
-    "@blockly/field-grid-dropdown": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.2.tgz",
-      "integrity": "sha512-eMtLY296n3i55EDd+8YHtnb1IpE6tesGGzSyPftlK1JEw5otBU+PLOTMORTqtaZX2KHc37dwOJcV51fEswd/qg==",
-      "requires": {}
     },
     "@commitlint/cli": {
       "version": "17.8.1",
@@ -8332,9 +8334,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.2.0.tgz",
-      "integrity": "sha512-s4QL9ogEMzc4Pxfe8Oi3Kmu6SQ0ts2thzmRYjdnMSEIVZFpBZ4OUuNKvpFICqujO0yfAo99zON8KzxAFw8hA1w==",
+      "version": "12.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.0-beta.0.tgz",
+      "integrity": "sha512-QXD6dXbsYFLzBs9umZRDhpllkM3Mdxtc9JnDMKksLzEFdFbl2CDl2JaKaw/rP5B0InpD1UrZPF7xT1ZRvJLS9w==",
       "requires": {
         "jsdom": "26.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "dependencies": {
     "@blockly/continuous-toolbox": "^7.0.1",
     "@blockly/field-colour": "^6.0.3",
-    "blockly": "^12.2.0"
+    "blockly": "^12.3.0-beta.0"
   }
 }


### PR DESCRIPTION
This PR updates scratch-blocks to depend on the latest beta of Blockly which includes changes necessary to make some of the recent commits to this repo work as intended.